### PR TITLE
incsearch will make neovim crash (neovim #5769 & incsearch #125), disable it when running in neovim

### DIFF
--- a/layers/+vim/better-defaults/config.vim
+++ b/layers/+vim/better-defaults/config.vim
@@ -33,7 +33,7 @@ endif
 " }
 
 " incsearch.vim {
-if IsDir('incsearch.vim') && !has('nvim')
+if IsDir('incsearch.vim')
     " incsearch.vim has bug with GUI vim
     if !has('gui_running')
         map /  <Plug>(incsearch-forward)

--- a/layers/+vim/better-defaults/config.vim
+++ b/layers/+vim/better-defaults/config.vim
@@ -33,7 +33,7 @@ endif
 " }
 
 " incsearch.vim {
-if IsDir('incsearch.vim')
+if IsDir('incsearch.vim') && !has('nvim')
     " incsearch.vim has bug with GUI vim
     if !has('gui_running')
         map /  <Plug>(incsearch-forward)

--- a/layers/+vim/better-defaults/packages.vim
+++ b/layers/+vim/better-defaults/packages.vim
@@ -23,16 +23,18 @@ MP 'danro/rename.vim',               { 'on' : 'Rename' }
 
 MP 'ntpeters/vim-better-whitespace', { 'on': 'StripWhitespace' }
 
-MP 'haya14busa/incsearch.vim',       { 'on': [
-            \   '<Plug>(incsearch-forward)',
-            \   '<Plug>(incsearch-backward)',
-            \   '<Plug>(incsearch-stay)' ]
-            \   }
-MP 'haya14busa/incsearch-fuzzy.vim',  { 'on': [
-            \   '<Plug>(incsearch-fuzzy-/)',
-            \   '<Plug>(incsearch-fuzzy-?)',
-            \   '<Plug>(incsearch-fuzzy-stay)' ]
-            \   }
+if !has('nvim')
+    MP 'haya14busa/incsearch.vim',       { 'on': [
+                \   '<Plug>(incsearch-forward)',
+                \   '<Plug>(incsearch-backward)',
+                \   '<Plug>(incsearch-stay)' ]
+                \   }
+    MP 'haya14busa/incsearch-fuzzy.vim',  { 'on': [
+                \   '<Plug>(incsearch-fuzzy-/)',
+                \   '<Plug>(incsearch-fuzzy-?)',
+                \   '<Plug>(incsearch-fuzzy-stay)' ]
+                \   }
+endif
 
 " Refer to https://github.com/junegunn/dotfiles  vimrc
 Plug 'scrooloose/nerdtree', { 'on': 'NERDTreeToggle' }

--- a/layers/+vim/better-defaults/packages.vim
+++ b/layers/+vim/better-defaults/packages.vim
@@ -23,19 +23,16 @@ MP 'danro/rename.vim',               { 'on' : 'Rename' }
 
 MP 'ntpeters/vim-better-whitespace', { 'on': 'StripWhitespace' }
 
-" will cause neovim crash (https://github.com/neovim/neovim/issues/5769)
-if !has('nvim')
-    MP 'haya14busa/incsearch.vim',       { 'on': [
-                \   '<Plug>(incsearch-forward)',
-                \   '<Plug>(incsearch-backward)',
-                \   '<Plug>(incsearch-stay)' ]
-                \   }
-    MP 'haya14busa/incsearch-fuzzy.vim',  { 'on': [
-                \   '<Plug>(incsearch-fuzzy-/)',
-                \   '<Plug>(incsearch-fuzzy-?)',
-                \   '<Plug>(incsearch-fuzzy-stay)' ]
-                \   }
-endif
+MP 'haya14busa/incsearch.vim',       { 'on': [
+            \   '<Plug>(incsearch-forward)',
+            \   '<Plug>(incsearch-backward)',
+            \   '<Plug>(incsearch-stay)' ]
+            \   }
+MP 'haya14busa/incsearch-fuzzy.vim',  { 'on': [
+            \   '<Plug>(incsearch-fuzzy-/)',
+            \   '<Plug>(incsearch-fuzzy-?)',
+            \   '<Plug>(incsearch-fuzzy-stay)' ]
+            \   }
 
 " Refer to https://github.com/junegunn/dotfiles  vimrc
 Plug 'scrooloose/nerdtree', { 'on': 'NERDTreeToggle' }

--- a/layers/+vim/better-defaults/packages.vim
+++ b/layers/+vim/better-defaults/packages.vim
@@ -23,16 +23,19 @@ MP 'danro/rename.vim',               { 'on' : 'Rename' }
 
 MP 'ntpeters/vim-better-whitespace', { 'on': 'StripWhitespace' }
 
-MP 'haya14busa/incsearch.vim',       { 'on': [
-            \   '<Plug>(incsearch-forward)',
-            \   '<Plug>(incsearch-backward)',
-            \   '<Plug>(incsearch-stay)' ]
-            \   }
-MP 'haya14busa/incsearch-fuzzy.vim',  { 'on': [
-            \   '<Plug>(incsearch-fuzzy-/)',
-            \   '<Plug>(incsearch-fuzzy-?)',
-            \   '<Plug>(incsearch-fuzzy-stay)' ]
-            \   }
+" will cause neovim crash (https://github.com/neovim/neovim/issues/5769)
+if !has('nvim')
+    MP 'haya14busa/incsearch.vim',       { 'on': [
+                \   '<Plug>(incsearch-forward)',
+                \   '<Plug>(incsearch-backward)',
+                \   '<Plug>(incsearch-stay)' ]
+                \   }
+    MP 'haya14busa/incsearch-fuzzy.vim',  { 'on': [
+                \   '<Plug>(incsearch-fuzzy-/)',
+                \   '<Plug>(incsearch-fuzzy-?)',
+                \   '<Plug>(incsearch-fuzzy-stay)' ]
+                \   }
+endif
 
 " Refer to https://github.com/junegunn/dotfiles  vimrc
 Plug 'scrooloose/nerdtree', { 'on': 'NERDTreeToggle' }


### PR DESCRIPTION
according to [neovim/neovim #5769](https://github.com/neovim/neovim/issues/5769) and [haya14busa/incsearch.vim #125](https://github.com/haya14busa/incsearch.vim/issues/125), incsearch plugin will cause neovim crash when do searching.

so it's better to temporarily  disable it when running under neovim.
