### PR TITLE
auto install vim-plug when start neovim and ~/.local/share/nvim/site/…

### DIFF
--- a/core/core_config.vim
+++ b/core/core_config.vim
@@ -72,7 +72,11 @@ endfunction
 function! LayersBegin()
 
     " Download vim-plug if unavailable
-    if empty(glob('~/.vim/autoload/plug.vim'))
+    if g:spacevim_nvim && empty(glob('~/.local/share/nvim/site/autoload/plug.vim'))
+        echo '==> Downloading vim-plug ......'
+	execute '!curl -sSfLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs
+		    \ https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+    elseif empty(glob('~/.vim/autoload/plug.vim'))
         echo '==> Downloading vim-plug ......'
         execute '!curl -fLo ~/.vim/autoload/plug.vim
                     \ https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'


### PR DESCRIPTION
it will give the following error message when start neovim, because of neovim is looking for vim-plug at  ~/.local/share/nvim/site/autoload/plug.vim.
> Error detected while processing function LayersBegin:
> line   15:
> E117: Unknown function: plug#begin
> [space-vim] The function Layers() does not exist, please add it to .spacevim.
> Error detected while processing function LayersEnd:
> line   21:
> E117: Unknown function: plug#end
> [space-vim] The function UserConfig() does not exist, please add it to .spacevim.

i've added a condition branch to solve this, when we are in neovim, and the directory is empty, automatically download vim-plugin.