### PR TITLE
Don't clone the whole history

### DIFF
--- a/git clone
+++ b/git clone
@@ -95,7 +95,7 @@ sync_repo() {
     then
         msg "\033[1;34m==>\033[0m Trying to clone $repo_name"
         mkdir -p "$repo_path"
-        git clone -b "$repo_branch" "$repo_uri" "$repo_path"
+        git clone -b "$repo_branch" "$repo_uri" "$repo_path" --depth=1
         ret="$?"
         success "Successfully cloned $repo_name."
     else


### PR DESCRIPTION
To make the installation faster we only clone from the last commit