### PR TITLE
[+checker/syntax-checking] Configure only ALE or syntastic, not both.

### DIFF
--- a/layers/+checkers/syntax-checking/config.vim
+++ b/layers/+checkers/syntax-checking/config.vim
@@ -1,6 +1,7 @@
 scriptencoding utf-8
 
-" ale {
+if g:spacevim_vim8 || g:spacevim_nvim
+    " ale {
     let g:ale_linters = {
                 \   'sh' : ['shellcheck'],
                 \   'vim' : ['vint'],
@@ -59,9 +60,10 @@ scriptencoding utf-8
 
     nmap <Leader>en <Plug>(ale_next)
     nmap <Leader>ep <Plug>(ale_previous)
-" }
-
-" syntastic {
+    nnoremap <Leader>ts :ALEToggle<CR>
+    " }
+else
+    " syntastic {
     let g:syntastic_python_checkers=['pyflakes']
     let g:syntastic_javascript_checkers=['jsl', 'jshint']
     let g:syntastic_html_checkers=['tidy', 'jshint']
@@ -70,4 +72,5 @@ scriptencoding utf-8
     let g:syntastic_aggregate_errors=1
 
     nnoremap <Leader>ts :SyntasticToggleMode<CR>
-" }
+    " }
+endif

--- a/layers/+checkers/syntax-checking/packages.vim
+++ b/layers/+checkers/syntax-checking/packages.vim
@@ -1,5 +1,5 @@
 if g:spacevim_vim8 || g:spacevim_nvim
-    MP 'w0rp/ale', { 'on': 'ALEEnable' }
+    MP 'w0rp/ale', { 'on': ['ALEEnable', 'ALEToggle'] }
 else
     MP 'scrooloose/syntastic',     { 'on': 'SyntasticCheck' }
 endif


### PR DESCRIPTION
Currently `layers/+checkers/syntax-checking/packages.vim` only installs either ale or syntastic, but the corresponding `config.vim` configures both. 

As of now, in neovim, pressing `<space>ts` would cause an error, since syntastic is not installed.

This PR changes `config.vim` to configure only the installed plug in. 
This allows `<leader>ts` to be bound to correctly toggle the installed plugin. 