### PR TITLE
Always include vim-tmux-navigator regardless of whether vim is started in tmux.

### DIFF
--- a/layers/+tools/tmux/packages.vim
+++ b/layers/+tools/tmux/packages.vim
@@ -1,5 +1,5 @@
+MP 'christoomey/vim-tmux-navigator'
 if g:spacevim_tmux
-    MP 'christoomey/vim-tmux-navigator'
     if funcs#LayerLoaded('unite')
         MP 'lucidstack/ctrlp-tmux.vim',{'on': 'CtrlPTmux'}
     endif


### PR DESCRIPTION
vim-tmux-navigator provides C-h,j,k,l key bindings for navigating between tmux splits **and between vim windows inside vim**.

Currently, if I include the `tmux` layer, but do not start vim inside tmux, vim window navigation with C-h,j,k,l also do not work.  I work on many machines, and do not use tmux on some of them.   It would be nice if we can get consistent window navigation keybindings inside and outside of tmux. 

This change proposed to always load `christoomey/vim-tmux-navigator` as long as the tmux layer is included.  This ensures that C-h,j,k,l always work for window navigation, both inside and outside of tmux.

Moreover, `christoomey/vim-tmux-navigator` already has a `s:InTmuxSession()` check.