### PR TITLE
Add ability to open NERDTree in current file's directory.

### DIFF
--- a/layers/+tools/file-manager/config.vim
+++ b/layers/+tools/file-manager/config.vim
@@ -15,6 +15,7 @@ scriptencoding utf-8
     nnoremap <F4> :NERDTreeToggle<CR>
     inoremap <F4> <ESC>:NERDTreeToggle<CR>
     nnoremap <Leader>ft :NERDTreeToggle<CR>
+    nnoremap <Leader>fr :NERDTreeFind<CR>
 " }
 
 " nerdtree-git-plugin {

--- a/layers/+tools/file-manager/config.vim
+++ b/layers/+tools/file-manager/config.vim
@@ -15,7 +15,7 @@ scriptencoding utf-8
     nnoremap <F4> :NERDTreeToggle<CR>
     inoremap <F4> <ESC>:NERDTreeToggle<CR>
     nnoremap <Leader>ft :NERDTreeToggle<CR>
-    nnoremap <Leader>fe :NERDTreeFind<CR>
+    nnoremap <Leader>fd :NERDTreeFind<CR>
 " }
 
 " nerdtree-git-plugin {

--- a/layers/+tools/file-manager/config.vim
+++ b/layers/+tools/file-manager/config.vim
@@ -15,7 +15,7 @@ scriptencoding utf-8
     nnoremap <F4> :NERDTreeToggle<CR>
     inoremap <F4> <ESC>:NERDTreeToggle<CR>
     nnoremap <Leader>ft :NERDTreeToggle<CR>
-    nnoremap <Leader>fr :NERDTreeFind<CR>
+    nnoremap <Leader>fe :NERDTreeFind<CR>
 " }
 
 " nerdtree-git-plugin {

--- a/layers/+tools/file-manager/packages.vim
+++ b/layers/+tools/file-manager/packages.vim
@@ -1,7 +1,7 @@
 MP 'danro/rename.vim',               { 'on' : 'Rename' }
 
 " Refer to https://github.com/junegunn/dotfiles  vimrc
-MP 'scrooloose/nerdtree', { 'on': 'NERDTreeToggle' }
+MP 'scrooloose/nerdtree', { 'on': ['NERDTreeToggle', 'NERDTreeFind'] }
 augroup nerd_loader
     autocmd!
     autocmd VimEnter * silent! autocmd! FileExplorer
@@ -12,5 +12,5 @@ augroup nerd_loader
                 \| endif
 augroup END
 
-MP 'Xuyuanp/nerdtree-git-plugin',             { 'on': 'NERDTreeToggle' }
-MP 'tiagofumo/vim-nerdtree-syntax-highlight', { 'on': 'NERDTreeToggle' }
+MP 'Xuyuanp/nerdtree-git-plugin', { 'on': ['NERDTreeToggle', 'NERDTreeFind'] }
+MP 'tiagofumo/vim-nerdtree-syntax-highlight', { 'on': ['NERDTreeToggle', 'NERDTreeFind'] }


### PR DESCRIPTION
Currently, `<Leader>ft` toggles NERDTree and opens it in the `current working directory`.
Often times, the `current working directory` is different from the current file's location. 

This change adds a shortcut `<Leader>fe` to open NERDTree in the current file's directory.

If you don't like the above hotkey assignment, please suggest a different key binding. Thanks!