### PR TITLE
Remove vim-nerdtree-syntax-highlight for speed

### DIFF
--- a/layers/+tools/file-manager/packages.vim
+++ b/layers/+tools/file-manager/packages.vim
@@ -13,4 +13,3 @@ augroup loadNerdtree
 augroup END
 
 MP 'Xuyuanp/nerdtree-git-plugin', { 'on': ['NERDTreeToggle', 'NERDTreeFind'] }
-MP 'tiagofumo/vim-nerdtree-syntax-highlight', { 'on': ['NERDTreeToggle', 'NERDTreeFind'] }


### PR DESCRIPTION
I didn't investigate why this plugin makes NERDTree slower, I just removed it

close #237 