### PR TITLE
Update packages.vim, 'mattn/gist-vim' depends on 'mattn/webapi-vim'

### DIFF
--- a/layers/+version-control/github/packages.vim
+++ b/layers/+version-control/github/packages.vim
@@ -1,2 +1,3 @@
 MP 'junegunn/vim-github-dashboard', { 'on': ['GHDashboard', 'GHActivity'] }
+MP 'mattn/webapi-vim',              { 'on': 'Gist' }
 MP 'mattn/gist-vim',                { 'on': 'Gist' }


### PR DESCRIPTION
'mattn/gist-vim' depends on 'mattn/webapi-vim', I simply add one line to add one line to install it. I'm not family with vimscript, please consider about it.