### PR TITLE
fix bug. when Quickfix window already opened, no need to "copen 8"

### DIFF
--- a/layers/+distributions/spacevim/config.vim
+++ b/layers/+distributions/spacevim/config.vim
@@ -29,7 +29,9 @@ augroup spacevimBasic
   autocmd BufEnter * :syntax sync maxlines=200
 
   " Open quickfix window automatically when something is feeded
-  autocmd QuickFixCmdPost * botright copen 8
+  if !exists("g:qfix_win") && a:forced == 0
+    autocmd QuickFixCmdPost * botright copen 8
+  endif
 
   " Close vim if the last edit buffer is closed, i.e., close NERDTree,
   " undotree, quickfix etc automatically.


### PR DESCRIPTION
when Quickfix window already vertical opened, execute script in buffer window will make the buffer window show only 8 lines。