### PR TITLE
add two line default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ function! UserConfig()
   " If your terminal(-emulator) supports true colors, uncomment the line below
   " call s:enable_termgui()
 
+  " If your want open mouse support, uncomment the line below
+  " set mouse-=a  
+
+  " If your don't want relative number, uncomment the line below
+  " set norelativenumber
+
 endfunction
 ```
 


### PR DESCRIPTION
I add a issue `https://github.com/liuchengxu/space-vim/issues/328`
thanks author help me to solve it.
I think norelative number and mouse support is frequently-used config, so I try to add it to .spacevim.