### PR TITLE
Switch to ncm2

### DIFF
--- a/layers/+completion/auto-completion/config.vim
+++ b/layers/+completion/auto-completion/config.vim
@@ -2,7 +2,6 @@ scriptencoding utf-8
 
 if has_key(g:plugs, 'vim-mucomplete')
   let g:mucomplete#enable_auto_at_startup = 1
-  set completeopt+=noselect
   inoremap <expr> <c-e> mucomplete#popup_exit("\<c-e>")
   inoremap <expr> <c-y> mucomplete#popup_exit("\<c-y>")
   inoremap <expr>  <cr> mucomplete#popup_exit("\<cr>")
@@ -11,6 +10,9 @@ if has_key(g:plugs, 'vim-mucomplete')
   iunmap <c-j>
   iunmap <c-h>
 endif
+
+" :h completeopt
+set completeopt=noinsert,menuone,noselect
 
 inoremap <expr> <Tab> spacevim#vim#complete#Tab()
 inoremap <expr> <S-Tab> spacevim#vim#complete#STab()

--- a/layers/+completion/auto-completion/packages.vim
+++ b/layers/+completion/auto-completion/packages.vim
@@ -1,14 +1,30 @@
-if g:spacevim.nvim
-  MP 'roxma/nvim-completion-manager'
-  MP 'roxma/nvim-cm-racer'
-  MP 'roxma/ncm-clang'
-  MP 'Shougo/neco-vim'
-  MP 'roxma/ncm-github'
-  MP 'fgrsnau/ncm-otherbuf'
-  MP 'roxma/nvim-cm-tern',  {'do': 'npm install'}
+if has("nvim-0.2.2") && has('python3') || exists('g:spacevim_use_ncm2')
+  let s:plugins = [
+        \ 'ncm2/ncm2',
+        \ 'roxma/nvim-yarp',
+        \ 'ncm2/ncm2-bufword',
+        \ 'ncm2/ncm2-tmux',
+        \ 'ncm2/ncm2-path',
+        \ 'ncm2/ncm2-jedi',
+        \ 'ncm2/ncm2-github',
+        \ 'ncm2/ncm2-abbrfuzzy',
+        \ 'ncm2/ncm2-racer',
+        \ 'ncm2/ncm2-pyclang',
+        \ ]
+  if g:spacevim.vim8
+    call add(s:plugins, 'roxma/vim-hug-neovim-rpc')
+  endif
+  " enable ncm2 for all buffer
+  autocmd BufEnter * call ncm2#enable_for_buffer()
+
 elseif g:spacevim.vim8
-  MP 'maralla/completor.vim'
-  MP 'maralla/completor-neosnippet'
+  let s:plugins = [
+        \ 'maralla/completor.vim',
+        \ 'maralla/completor-neosnippet',
+        \ ]
+
 else
-  MP 'lifepillar/vim-mucomplete'
+  let s:plugins = ['lifepillar/vim-mucomplete']
 endif
+
+call extend(g:spacevim.plugins, s:plugins)

--- a/layers/+completion/auto-completion/packages.vim
+++ b/layers/+completion/auto-completion/packages.vim
@@ -12,11 +12,6 @@ if exists('g:spacevim_use_ncm2') || has("nvim-0.2.2") && has('python3')
         \ 'ncm2/ncm2-pyclang',
         \ ]
   if g:spacevim.vim8
-    try
-      py3 import neovim
-    catch
-      call system('pip3 install neovim')
-    endtry
     call add(s:plugins, 'roxma/vim-hug-neovim-rpc')
   endif
   " enable ncm2 for all buffer

--- a/layers/+completion/auto-completion/packages.vim
+++ b/layers/+completion/auto-completion/packages.vim
@@ -1,4 +1,4 @@
-if has("nvim-0.2.2") && has('python3') || exists('g:spacevim_use_ncm2')
+if exists('g:spacevim_use_ncm2') || has("nvim-0.2.2") && has('python3')
   let s:plugins = [
         \ 'ncm2/ncm2',
         \ 'roxma/nvim-yarp',
@@ -12,6 +12,11 @@ if has("nvim-0.2.2") && has('python3') || exists('g:spacevim_use_ncm2')
         \ 'ncm2/ncm2-pyclang',
         \ ]
   if g:spacevim.vim8
+    try
+      py3 import neovim
+    catch
+      call system('pip3 install neovim')
+    endtry
     call add(s:plugins, 'roxma/vim-hug-neovim-rpc')
   endif
   " enable ncm2 for all buffer

--- a/layers/+completion/auto-completion/packages.vim
+++ b/layers/+completion/auto-completion/packages.vim
@@ -9,6 +9,7 @@ if exists('g:spacevim_use_ncm2') || has("nvim-0.2.2") && has('python3')
         \ 'ncm2/ncm2-github',
         \ 'ncm2/ncm2-abbrfuzzy',
         \ 'ncm2/ncm2-racer',
+        \ 'ncm2/ncm2-go',
         \ 'ncm2/ncm2-pyclang',
         \ ]
   if g:spacevim.vim8

--- a/layers/+completion/auto-completion/packages.vim
+++ b/layers/+completion/auto-completion/packages.vim
@@ -1,3 +1,6 @@
+" space-vim will use completor.vim for vim8 by default.
+" If you want to use ncm2 when using vim8, configure it explicitly.
+" let g:spacevim_use_ncm2 = 1
 if exists('g:spacevim_use_ncm2') || has("nvim-0.2.2") && has('python3')
   let s:plugins = [
         \ 'ncm2/ncm2',
@@ -15,7 +18,7 @@ if exists('g:spacevim_use_ncm2') || has("nvim-0.2.2") && has('python3')
   if g:spacevim.vim8
     call add(s:plugins, 'roxma/vim-hug-neovim-rpc')
   endif
-  " enable ncm2 for all buffer
+  " Enable ncm2 for all buffer
   autocmd BufEnter * call ncm2#enable_for_buffer()
 
 elseif g:spacevim.vim8


### PR DESCRIPTION
NCM has been deprecated for a while, its successor ncm2 is usable.
Switch to ncm2 and provide an option `g:spacevim_use_ncm2` to use ncm2
explicitly.