### PR TITLE
Introduce on_event option to MP

### DIFF
--- a/core/autoload/spacevim.vim
+++ b/core/autoload/spacevim.vim
@@ -115,7 +115,7 @@ function! s:my_plugin(plugin, ...) abort
       let l:load = printf("call plug#load('%s')", l:name)
       execute "augroup" l:group
       autocmd!
-      execute 'autocmd' l:events '*' l:load '| autocmd!' l:group
+      execute 'autocmd' l:events '*' l:load '|' 'autocmd!' l:group
       execute 'augroup END'
     endif
   endif

--- a/core/autoload/spacevim.vim
+++ b/core/autoload/spacevim.vim
@@ -101,13 +101,23 @@ function! s:parse_options(arg)
   endif
 endfunction
 
-" This is an only one possible extra argument: plug option
+" This is an only one possible extra argument: plug option, dict
 function! s:my_plugin(plugin, ...) abort
   if index(g:spacevim.plugins, a:plugin) < 0
     call add(g:spacevim.plugins, a:plugin)
   endif
   if a:0 == 1
     let s:plug_options[a:plugin] = a:1
+    if has_key(a:1, 'on_event')
+      let l:group = 'load/'.a:plugin
+      let l:name = split(a:plugin, '/')[1]
+      let l:events = join(s:to_a(a:1.on_event), ',')
+      let l:load = printf("call plug#load('%s')", l:name)
+      execute "augroup" l:group
+      autocmd!
+      execute 'autocmd' l:events '*' l:load '| autocmd!' l:group
+      execute 'augroup END'
+    endif
   endif
 endfunction
 

--- a/core/autoload/spacevim/plug/youcompleteme.vim
+++ b/core/autoload/spacevim/plug/youcompleteme.vim
@@ -39,12 +39,14 @@ function! s:load_ycm()
   endif
 endfunction
 
+" Load for supported types when loading via timer
 function! spacevim#plug#youcompleteme#invoke(timer) abort
   if !exists('g:loaded_youcompleteme')
     call plug#load('YouCompleteMe')
   endif
 endfunction
 
+" Deprecated, use on_event option, load for all types when events are triggered
 function! spacevim#plug#youcompleteme#load() abort
   if !exists('g:loaded_youcompleteme')
     call s:load_ycm()

--- a/layers/+programming/code-snippets/packages.vim
+++ b/layers/+programming/code-snippets/packages.vim
@@ -1,10 +1,4 @@
 " Refer to https://github.com/junegunn/vim-plug/wiki/faq
 " Load on nothing
-MP 'SirVer/ultisnips', { 'on': [] }
-MP 'honza/vim-snippets', { 'on': [] }
-
-augroup loadSnips
-  autocmd!
-  autocmd InsertEnter * call plug#load('ultisnips', 'vim-snippets')
-              \| autocmd! loadSnips
-augroup END
+MP 'SirVer/ultisnips', { 'on': [], 'on_event': 'InsertEnter' }
+MP 'honza/vim-snippets', { 'on': [], 'on_event': 'InsertEnter' }

--- a/layers/+tools/ycmd/packages.vim
+++ b/layers/+tools/ycmd/packages.vim
@@ -1,13 +1,10 @@
 
 MP 'rdnetto/YCM-Generator',  { 'on': ['YcmGenerateConfig', 'CCGenerateConfig'], 'branch': 'stable' }
 
-MP 'Valloric/YouCompleteMe', { 'do': function('spacevim#plug#youcompleteme#build'), 'on': [] }
+MP 'Valloric/YouCompleteMe', { 'do': function('spacevim#plug#youcompleteme#build'), 'on': [],
+      \ 'on_event': ['CursorHold', 'CursorHoldI', 'InsertEnter'] }
 autocmd! User YouCompleteMe call spacevim#autocmd#youcompleteme#Init()
 
 if g:spacevim.timer
   call timer_start(1000, 'spacevim#plug#youcompleteme#invoke')
 endif
-augroup loadYcm
-  autocmd!
-  autocmd CursorHold,CursorHoldI,InsertEnter * call spacevim#plug#youcompleteme#load() | autocmd! loadYcm
-augroup END


### PR DESCRIPTION
`on_event` could simplify the plugin loading dependent on events based on the
exposed API `plug#load()`, e.g., InsertEnter, CursorHold.