### PR TITLE
Fix no such highlight group name Warnings

### DIFF
--- a/layers/+tools/lsp/config.vim
+++ b/layers/+tools/lsp/config.vim
@@ -28,7 +28,7 @@ let g:LanguageClient_serverCommands = {
 \        },
 \        2: {
 \            "name": "Warning",
-\            "texthl": "Warnings",
+\            "texthl": "Warning",
 \            "signText": "⚠",
 \            "signTexthl": "WarningMsg",
 \        },


### PR DESCRIPTION
I believe it was a typo. Issue was found during the Python code editing.