### PR TITLE
Improve nerdtree syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ CHANGELOG
 
 - a command line mapping to mimic `<C-R>` in bash via `:History:`.
 - more file extensions highlight for nerdtree.
-- use `g:spacevim_lsp_engine` to specify which LSP plugin to use: `coc`, `lcn` or `vim_lsp`.
+- add `g:spacevim_lsp_engine` to specify which LSP plugin to use: `coc`, `lcn` or `vim_lsp`.
+- add `g:spacevim_disable_nerdtree_arrow_icons` to disable nerdtree arrow icons.
+- add `g:spacevim_nerd_fonts` to use more pretty icons in nerdtree when using nerd fonts.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ let g:spacevim_layers = [
 " Uncomment the following line if your terminal(-emulator) supports true colors.
 " let g:spacevim_enable_true_color = 1
 
+" Uncomment the following if you have some nerd font installed.
+" let g:spacevim_nerd_fonts = 1
+
 " If you want to have more control over the layer, try using Layer command.
 " if g:spacevim.gui
 "   Layer 'airline'

--- a/core/autoload/spacevim/autocmd.vim
+++ b/core/autoload/spacevim/autocmd.vim
@@ -1,0 +1,19 @@
+function! spacevim#autocmd#GUIEnter() abort
+  " http://stackoverflow.com/questions/5933568/disable-blinking-at-the-first-last-line-of-the-file
+  set t_vb=
+
+  " Refer to http://vim.wikia.com/wiki/Show_tab_number_in_your_tab_line
+  set guioptions-=e
+
+  " Restore screen
+  let g:screen_size_restore_pos = get(g:, 'screen_size_restore_pos', 1)
+  let g:screen_size_by_vim_instance = get(g:, 'screen_size_by_vim_instance', 1)
+  autocmd VimEnter * if g:screen_size_restore_pos == 1 | call spacevim#vim#gui#ScreenRestore() | endif
+  autocmd VimLeavePre * if g:screen_size_restore_pos == 1 | call spacevim#vim#gui#ScreenSave() | endif
+
+  " Manipulate font size, from tpope
+  command! Bigger  :let &guifont = substitute(&guifont, '\d\+$', '\=submatch(0)+1', '')
+  command! Smaller :let &guifont = substitute(&guifont, '\d\+$', '\=submatch(0)-1', '')
+  noremap + :Bigger<CR>
+  noremap - :Smaller<CR>
+endfunction

--- a/core/autoload/spacevim/autocmd/nerdtree.vim
+++ b/core/autoload/spacevim/autocmd/nerdtree.vim
@@ -65,7 +65,8 @@ function! spacevim#autocmd#nerdtree#Init()
   let g:NERDTreeAutoDeleteBuffer = 1
 
   " Disable arrow icons at the left side of folders for NERDTree.
-  if has_key(g:plugs, 'vim-devicons')
+  " For the benefits of vim-devicons.
+  if get(g:, 'spacevim_disable_nerdtree_arrow_icons', 0)
     let g:NERDTreeDirArrowExpandable = "\u00a0"
     let g:NERDTreeDirArrowCollapsible = "\u00a0"
   else

--- a/core/autoload/spacevim/autocmd/nerdtree.vim
+++ b/core/autoload/spacevim/autocmd/nerdtree.vim
@@ -69,6 +69,9 @@ function! spacevim#autocmd#nerdtree#Init()
   if get(g:, 'spacevim_disable_nerdtree_arrow_icons', 0)
     let g:NERDTreeDirArrowExpandable = "\u00a0"
     let g:NERDTreeDirArrowCollapsible = "\u00a0"
+  elseif get(g:, 'spacevim_nerd_fonts', 0)
+    let g:NERDTreeDirArrowExpandable = ''
+    let g:NERDTreeDirArrowCollapsible = ''
   else
     " ❯
     let g:NERDTreeDirArrowExpandable = "\u276f"

--- a/core/autoload/spacevim/lang/lsp.vim
+++ b/core/autoload/spacevim/lang/lsp.vim
@@ -6,3 +6,11 @@ function! spacevim#lang#lsp#register_rls() abort
           \ 'whitelist': ['rust'],
           \ })
 endfunction
+
+function! spacevim#lang#lsp#register_go() abort
+  call lsp#register_server({
+          \ 'name': 'go-langserver',
+          \ 'cmd': {server_info->['go-langserver', '-gocodecompletion']},
+          \ 'whitelist': ['go'],
+          \ })
+endfunction

--- a/core/ftplugin/fugitiveblame.vim
+++ b/core/ftplugin/fugitiveblame.vim
@@ -1,0 +1,1 @@
+nnoremap <silent><buffer> q :q!<CR>

--- a/core/syntax/nerdtree.vim
+++ b/core/syntax/nerdtree.vim
@@ -43,7 +43,7 @@ let s:hi_group = {
       \ 'Include':     [ 'SpecialComment', [ 'history', 'vimsize'                                    ]  ] ,
       \ 'Conditional': [ 'SpecialKey',     [ 'log', 'tags'                                           ]  ] ,
       \ 'SpecialKey':  [ 'PreProc',        [ 'lock'                                                  ]  ] ,
-      \ 'PreProc':     [ 'TypeDef',        [ 'LICENSE'                                               ]  ] ,
+      \ 'PreProc':     [ 'SpecialComment', [ 'LICENSE', 'AUTHOR',                                    ]  ] ,
       \ 'TypeDef':     [ 'Comment',        [ 'Makefile'                                              ]  ] ,
       \ 'Delimiter':   [ 'Macro',          [ 'docs', 'doc', 'cnx', 'pdf'                             ]  ] ,
       \ }

--- a/core/syntax/nerdtree.vim
+++ b/core/syntax/nerdtree.vim
@@ -27,28 +27,28 @@ function! s:hl(extension, group, ext_group)
 endfunction
 
 let s:hi_group = {
-      \ 'Comment': ['Constant', ['md', 'org', 'txt']],
-      \ 'Constant': ['SpecialComment', ['gitignore', 'editorconfig', 'gitconfig']],
-      \ 'String': ['Character', ['toml', 'yml', 'ini', 'info', 'conf', 'yaml']],
-      \ 'Character': ['Number', ['png', 'svg', 'jpg', 'bmp', 'gif']],
-      \ 'Number': ['Float', ['sass', 'scss', 'css', 'less', 'coffee']],
-      \ 'Float': ['Identifier', ['sh', 'bash', 'zsh', 'ksh', 'ps1', 'fish', 'bat', 'cmd']],
-      \ 'Identifier': ['Function', ['vim', 'ts', 'vue', 'swift', 'dart']],
-      \ 'Function': ['Statement', ['html', 'js', 'jsx', 'ts']],
-      \ 'Statement': ['Label', ['py', 'pyc', 'pyo', 'rb', 'php', 'lua']],
-      \ 'Label': ['Operator', ['hs', 'go', 'java']],
-      \ 'Operator': ['SpecialComment', ['rc', 'lesshst']],
-      \ 'PreCondit': ['SpecialComment', ['profile', 'zshenv']],
-      \ 'Boolean': ['Include', ['cpp', 'cc', 'hpp', 'cxx', 'hxx', 'h', 'rs']],
-      \ 'Include': ['SpecialComment', ['history', 'vimsize']],
-      \ 'Conditional': ['SpecialKey', ['log', 'tags']],
-      \ 'SpecialKey': ['PreProc', ['lock']],
-      \ 'PreProc': ['TypeDef', ['LICENSE']],
-      \ 'TypeDef': ['Comment', ['Makefile']],
+      \ 'Comment':     [ 'Constant',       [ 'md', 'org', 'txt'                                      ]  ] ,
+      \ 'Constant':    [ 'SpecialComment', [ 'ignore', 'editorconfig', 'gitconfig'                   ]  ] ,
+      \ 'String':      [ 'Character',      [ 'toml', 'yml', 'ini', 'info', 'conf', 'yaml', 'json'    ]  ] ,
+      \ 'Character':   [ 'Number',         [ 'png', 'svg', 'jpg', 'bmp', 'gif'                       ]  ] ,
+      \ 'Number':      [ 'Float',          [ 'sass', 'scss', 'css', 'less', 'coffee'                 ]  ] ,
+      \ 'Float':       [ 'Identifier',     [ 'sh', 'ps1', 'bat', 'cmd'                               ]  ] ,
+      \ 'Identifier':  [ 'Function',       [ 'vim', 'swift', 'dart'                                  ]  ] ,
+      \ 'Function':    [ 'Statement',      [ 'html', 'ts', 'vue', 'js', 'jsx', 'ts'                  ]  ] ,
+      \ 'Statement':   [ 'Label',          [ 'py', 'pyc', 'pyo', 'rb', 'php', 'lua'                  ]  ] ,
+      \ 'Label':       [ 'Operator',       [ 'hs', 'go', 'java', 'rs'                                ]  ] ,
+      \ 'Operator':    [ 'SpecialComment', [ 'rc', 'lesshst'                                         ]  ] ,
+      \ 'PreCondit':   [ 'SpecialComment', [ 'profile', 'zshenv'                                     ]  ] ,
+      \ 'Boolean':     [ 'Include',        [ 'cpp', 'cc', 'hpp', 'cxx', 'hxx', 'h'                   ]  ] ,
+      \ 'Include':     [ 'SpecialComment', [ 'history', 'vimsize'                                    ]  ] ,
+      \ 'Conditional': [ 'SpecialKey',     [ 'log', 'tags'                                           ]  ] ,
+      \ 'SpecialKey':  [ 'PreProc',        [ 'lock'                                                  ]  ] ,
+      \ 'PreProc':     [ 'TypeDef',        [ 'LICENSE'                                               ]  ] ,
+      \ 'TypeDef':     [ 'Comment',        [ 'Makefile'                                              ]  ] ,
+      \ 'Delimiter':   [ 'Macro',          [ 'docs', 'doc', 'cnx', 'pdf'                             ]  ] ,
       \ }
 
 function! s:def_hi() abort
-  let groups = keys(s:hi_group)
   for [group, exts] in items(s:hi_group)
     let [ext_group, exts] = [exts[0], exts[1]]
     for ext in exts

--- a/init.spacevim
+++ b/init.spacevim
@@ -17,6 +17,9 @@ let g:spacevim_layers = [
 " Uncomment the following line if your terminal(-emulator) supports true colors.
 " let g:spacevim_enable_true_color = 1
 
+" Uncomment the following if you have some nerd font installed.
+" let g:spacevim_nerd_fonts = 1
+
 " If you want to have more control over the layer, try using Layer command.
 " if g:spacevim.gui
 "   Layer 'airline'

--- a/layers/+distributions/spacevim/config.vim
+++ b/layers/+distributions/spacevim/config.vim
@@ -35,12 +35,6 @@ augroup spacevimBasic
   " http://vim.wikia.com/wiki/Speed_up_Syntax_Highlighting
   autocmd BufEnter * :syntax sync maxlines=200
 
-  " Open quickfix window automatically when something is feeded
-  autocmd QuickFixCmdPost *
-        \ if !len(filter(range(1, winnr('$')), 'getwinvar(v:val, "&ft") == "qf"')) && len(getqflist())
-        \| copen 8
-        \|endif
-
   " Close vim if the last edit buffer is closed, i.e., close NERDTree,
   " undotree, quickfix etc automatically.
   " autocmd BufEnter * if 0 == len(filter(range(1, winnr('$')), 'empty(getbufvar(winbufnr(v:val), "&bt"))')) | qa! | endif
@@ -69,21 +63,13 @@ augroup spacevimBasic
   " http://vim.wikia.com/wiki/Always_start_on_first_line_of_git_commit_message
   autocmd BufEnter * if &filetype == "gitcommit" | call setpos('.', [0, 1, 1, 0]) | endif
 
-  function! s:OnGUIEnter() abort
-    " http://stackoverflow.com/questions/5933568/disable-blinking-at-the-first-last-line-of-the-file
-    set t_vb=
+  " Open quickfix window automatically when something is feeded
+  autocmd QuickFixCmdPost *
+        \ if !len(filter(range(1, winnr('$')), 'getwinvar(v:val, "&ft") == "qf"')) && len(getqflist())
+        \| copen 8
+        \|endif
 
-    " Refer to http://vim.wikia.com/wiki/Show_tab_number_in_your_tab_line
-    set guioptions-=e
-
-    " Restore screen
-    let g:screen_size_restore_pos = get(g:, 'screen_size_restore_pos', 1)
-    let g:screen_size_by_vim_instance = get(g:, 'screen_size_by_vim_instance', 1)
-    autocmd VimEnter * if g:screen_size_restore_pos == 1 | call spacevim#vim#gui#ScreenRestore() | endif
-    autocmd VimLeavePre * if g:screen_size_restore_pos == 1 | call spacevim#vim#gui#ScreenSave() | endif
-  endfunction
-
-  autocmd GUIEnter * call s:OnGUIEnter()
+  autocmd GUIEnter * call spacevim#autocmd#GUIEnter()
 
   if !spacevim#load('chinese')
     silent! set $LANG = 'en_US'

--- a/layers/+distributions/spacevim/config.vim
+++ b/layers/+distributions/spacevim/config.vim
@@ -18,16 +18,19 @@ augroup spacevimBasic
         \|  setlocal syntax=off
         \|endif
 
-  " Restore cursor position when opening file
-  autocmd BufReadPost *
-        \ if line("'\"") > 1 && line("'\"") <= line("$")
-        \|  execute "normal! g`\""
-        \|endif
+  function! s:OnBufReadPost() abort
+    " Restore cursor position when opening file
+    if line("'\"") > 1 && line("'\"") <= line("$")
+      execute "normal! g`\""
+    endif
 
-  autocmd BufReadPost *
-        \ if line('$') > 1000
-        \|  silent! set norelativenumber
-        \|endif
+    " Disable relative number when having too many lines.
+    if line('$') > 1000
+      silent! set norelativenumber
+    endif
+  endfunction
+
+  autocmd BufReadPost * call s:OnBufReadPost()
 
   " http://vim.wikia.com/wiki/Speed_up_Syntax_Highlighting
   autocmd BufEnter * :syntax sync maxlines=200
@@ -66,15 +69,21 @@ augroup spacevimBasic
   " http://vim.wikia.com/wiki/Always_start_on_first_line_of_git_commit_message
   autocmd BufEnter * if &filetype == "gitcommit" | call setpos('.', [0, 1, 1, 0]) | endif
 
-  " http://stackoverflow.com/questions/5933568/disable-blinking-at-the-first-last-line-of-the-file
-  autocmd GUIEnter * set t_vb=
+  function! s:OnGUIEnter() abort
+    " http://stackoverflow.com/questions/5933568/disable-blinking-at-the-first-last-line-of-the-file
+    set t_vb=
 
-  if g:spacevim.gui
+    " Refer to http://vim.wikia.com/wiki/Show_tab_number_in_your_tab_line
+    set guioptions-=e
+
+    " Restore screen
     let g:screen_size_restore_pos = get(g:, 'screen_size_restore_pos', 1)
     let g:screen_size_by_vim_instance = get(g:, 'screen_size_by_vim_instance', 1)
     autocmd VimEnter * if g:screen_size_restore_pos == 1 | call spacevim#vim#gui#ScreenRestore() | endif
     autocmd VimLeavePre * if g:screen_size_restore_pos == 1 | call spacevim#vim#gui#ScreenSave() | endif
-  endif
+  endfunction
+
+  autocmd GUIEnter * call s:OnGUIEnter()
 
   if !spacevim#load('chinese')
     silent! set $LANG = 'en_US'
@@ -92,9 +101,5 @@ augroup END
 hi ExtraWhitespace guifg=#FF2626 gui=underline ctermfg=124 cterm=underline
 match ExtraWhitespace /\s\+$/
 
-" Refer to http://vim.wikia.com/wiki/Show_tab_number_in_your_tab_line
-if g:spacevim.gui
-  set guioptions-=e
-endif
 silent! set showtabline=1
 silent! set tabline=%!spacevim#vim#tab#TabLine()

--- a/layers/+tools/file-manager/README.md
+++ b/layers/+tools/file-manager/README.md
@@ -33,3 +33,4 @@ Key Binding                        | Mode   | Description
 - [vimfiler.vim](https://github.com/Shougo/vimfiler.vim)
 - [easytree.vim](https://github.com/troydm/easytree.vim)
 - [vim-filebeagle](https://github.com/jeetsukumaran/vim-filebeagle)
+- [vaffle.vim](https://github.com/cocopon/vaffle.vim)

--- a/layers/+tools/lsp/config.vim
+++ b/layers/+tools/lsp/config.vim
@@ -106,6 +106,9 @@ function! s:vim_lsp() abort
   if executable('rls')
     autocmd User lsp_setup call spacevim#lang#lsp#register_rls()
   endif
+  if executable('go-langserver')
+    autocmd User lsp_setup call spacevim#lang#lsp#register_go()
+  endif
 endfunction
 
 call s:{g:spacevim_lsp_engine}()


### PR DESCRIPTION
- support the dev-icons and file name highlight in nerdtree.
- refactor layers/+distributions/spacevim/config.vim, split spacevim/autocmd.vim out.
-  add `g:spacevim_disable_nerdtree_arrow_icons` to disable nerdtree arrow icons.
- add `g:spacevim_nerd_fonts` to use more pretty icons in nerdtree when using nerd fonts.