### PR TITLE
Modify the order of determination conditions to support vimR

### DIFF
--- a/core/autoload/spacevim/autocmd.vim
+++ b/core/autoload/spacevim/autocmd.vim
@@ -17,7 +17,7 @@ function! spacevim#autocmd#GUIEnter() abort
   noremap + :Bigger<CR>
   noremap - :Smaller<CR>
 
-  if empty(&guifont) && g:spacevim.os.windows
+  if g:spacevim.os.windows && empty(&guifont)
     let &guifont = 'Consolas:h13'
   endif
 


### PR DESCRIPTION
Since VimR does not have option `guifont`([#259](https://github.com/qvacua/vimr/issues/259#issuecomment-245967236)), it will popup an `Unknown option: guifont` error when you open a new native-window.![image](https://user-images.githubusercontent.com/7496084/55271688-ca84be00-52eb-11e9-8ff7-9296472553c5.png)

And because VimR can only work on macOS, I think it's the best practice to determine OS first, then `guifont`.
