### PR TITLE
Fix: DeprecationWarning

### DIFF
--- a/layers/+lang/python/packages.vim
+++ b/layers/+lang/python/packages.vim
@@ -2,5 +2,5 @@ MP 'jeetsukumaran/vim-pythonsense'
 if g:spacevim.speed_up_via_timer
   MP 'python-mode/python-mode', { 'on': [] }
 else
-  MP 'python-mode/python-mode', { 'for': 'python' }
+  MP 'python-mode/python-mode', { 'for': 'python', 'branch': 'develop' }
 endif


### PR DESCRIPTION
Fix:
```
Deprecation Warning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
```