### PR TITLE
add option g:spacevim_enable_whitespace to enable whitespace automatically

### DIFF
--- a/core/doc/spacevim.txt
+++ b/core/doc/spacevim.txt
@@ -36,7 +36,7 @@ equivalent to `.spacemacs` in spacemacs.
 space-vim use `~/.spacevim` as configuration file, which should be composed of
 some global options and two functions:
 
-  |UserInit()|    - You can add your own plugins in this function. 
+  |UserInit()|    - You can add your own plugins in this function.
   |UserConfig()|  - Used for overriding the default options in space-vim.
 
 **Don't edit `~/.space-vim/init.spacevim`**. It's merely a template for
@@ -47,7 +47,7 @@ configure space-vim.
 3. Global Options                                            *spacevim-options*
 
 g:spacevim_layers                                           *g:spacevim_layers*
-  
+
   Type: |List|
   Default: `['fzf', 'better-defaults', 'which-key']`
 
@@ -90,6 +90,13 @@ g:spacevim_enable_startify                              *g:spacevim_enable_start
   Default: `1`
 
   Set it to `0` if you want to disable startify completely.
+
+g:spacevim_enable_whitespace
+  Type: |Number|
+  Default: `0`
+
+  By default, vim-better-whitespace is enabled only when you execute `StripWhitespace`(<Leader>xd).
+  Set it to `1` if you want to enable it automatically.
 
 g:spacevim_speed_up_via_timer                     *g:spacevim_speed_up_via_timer*
   Type: |Number|

--- a/layers/+distributions/better-defaults/packages.vim
+++ b/layers/+distributions/better-defaults/packages.vim
@@ -36,7 +36,11 @@ endif
 " MP 'kana/vim-operator-user',         { 'on': '<Plug>(operator-flashy)' }
 " MP 'haya14busa/vim-operator-flashy', { 'on': '<Plug>(operator-flashy)' }
 
-MP 'ntpeters/vim-better-whitespace', { 'on': 'StripWhitespace' }
+if get(g:, "spacevim_enable_whitespace", 0)
+  MP 'ntpeters/vim-better-whitespace'
+else
+  MP 'ntpeters/vim-better-whitespace' , { 'on': 'StripWhitespace' }
+endif
 
 if has('patch-8.0.1238')
   MP 'haya14busa/is.vim'


### PR DESCRIPTION
By default, vim-better-whitespace is enabled only when you execute `StripWhitespace`(`<Leader>xd`).

But if you didn't notice any unwanted whitespace or you don't have a habit to check for the whitespace, the plugin is useless.

Anyway, this PR provides an option to enable it by default. Adding `let g:spacevim_enable_whitespace = 1` in ~/.spacevim to enable it.


Please check https://github.com/ntpeters/vim-better-whitespace home page for any other options like `let g:strip_whitespace_on_save=1`.

If you think `let g:spacevim_enable_whitespace = 1` should be the default config, please modify the code and ignore this PR.
