### PR TITLE
update lsp cache format according to ccls repo

### DIFF
--- a/layers/+tools/lsp/settings.json
+++ b/layers/+tools/lsp/settings.json
@@ -3,6 +3,8 @@
         "clippy_preference": "on"
     },
     "initializationOptions": {
-      "cacheDirectory": "/tmp/ccls"
+        "cache": {
+            "directory": "/tmp/ccls"
+        }
     }
 }


### PR DESCRIPTION
The lsp-cache-dir in old settings.json is not working.

The format of options for ccls was already changed according to https://github.com/MaskRay/ccls/commit/05d1fbfc5b751f76aee6c636d69a46294dc18d48

So this update fixes it.
