### PR TITLE
Do not load startify when vim is invoked as view or vi

### DIFF
--- a/layers/+distributions/better-defaults/packages.vim
+++ b/layers/+distributions/better-defaults/packages.vim
@@ -20,7 +20,7 @@ if get(g:, 'spacevim_enable_startify', 1)
   autocmd! User vim-startify call spacevim#autocmd#startify#Init()
 
   function! s:LoadStartifyIfNoArgs() abort
-    if !argc()
+    if !argc() && v:progname =~ "vim$"
       call plug#load('vim-startify')
       silent! Startify
     endif


### PR DESCRIPTION
Usually I pipe the diff command to `view`, like this:

```bash
diff -u stuff-origin.txt stuff-modified.txt |view -
```

And it uses to open a 2nd buffer with `Startify` since I use space-vim.

I've tried to detect if something is passed on `stdin` on startup to disable Startify, but this approach was not successful.

The other approach was to enable Startify only if the executable endswith `vim`. This is this PR.

IMHO it makes sense to skip loading Startify when vim/neovim is invoked with alternative command such as `view`.

