### PR TITLE
Remove <S-Tab> from default key bindings

### DIFF
--- a/layers/+distributions/better-defaults/README.md
+++ b/layers/+distributions/better-defaults/README.md
@@ -2,16 +2,20 @@
 
 ## Table of Contents
 
-<!-- vim-markdown-toc GFM -->
+<!-- TOC GFM -->
+
 * [Description](#description)
 * [Install](#install)
 * [Key Bindings](#key-bindings)
-    * [Basic](#basic)
-    * [Buffer](#buffer)
-    * [Window](#window)
-    * [Others](#others)
+  * [Basic](#basic)
+  * [Buffer](#buffer)
+  * [Tab](#tab)
+  * [Window](#window)
+  * [Others](#others)
+* [Related Projects](#related-projects)
 
-<!-- vim-markdown-toc -->
+<!-- /TOC -->
+
 
 ## Description
 
@@ -57,9 +61,17 @@ Key Binding          | Mode   | Description
 :---:                | :---:  | :---:
 <kbd>SPC b p</kbd>   | Normal | **p**revious **b**uffer, 上一个缓冲区
 <kbd>SPC b n</kbd>   | Normal | **n**ext **b**uffer, 下一个缓冲区
-<kbd>\<Tab></kbd>    | Normal | switch buffer, equal to <kbd>SPC b n</kbd>, 等同于 <kbd>SPC b n</kbd>
 <kbd>SPC b d</kbd>   | Normal | **d**elete current buffer, 删除当前缓冲区
 <kbd>SPC b k</kbd>   | Normal | **k**ill current buffer, 杀掉当前缓冲区
+<kbd>[ b</kbd>       | Normal | previous buffer, 上一个缓冲区
+<kbd>] b</kbd>       | Normal | next buffer, 下一个缓冲区
+
+### Tab
+
+Key Binding          | Mode   | Description
+:---:                | :---:  | :---:
+<kbd>[ t</kbd>       | Normal | previous tab
+<kbd>] t</kbd>       | Normal | next tab
 
 ### Window
 

--- a/layers/+distributions/better-defaults/keybindings.vim
+++ b/layers/+distributions/better-defaults/keybindings.vim
@@ -4,9 +4,6 @@ nnoremap <Leader>fR :source $MYVIMRC<CR>
 " Replace the word under cursor in current file
 nnoremap <leader>rc :%s/\<<C-r><C-w>\>/
 
-" Use Tab to switch buffer
-" nnoremap <Tab> :bn<CR>
-nnoremap <S-Tab> :bp<CR>
 " if maparg('<C-I>', 'n') != ''
   " nunmap <C-I>
 " endif


### PR DESCRIPTION
Since \<Tab> is no longer being used for buffer switching, \<S-Tab>
should be removed too for consistency.

Close #426