### PR TITLE
Add more fuzzy finders support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 - support neovim's floating window in fzf layer.
 - support crude GotoDefinition for vim <SID> and autoload function in space-vim itself.
 - add `gitbase` shortcuts.
+- add more fuzzy finders support(#428)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
 ### Changed
 
 - try to wrap fzf and unite.
+- `<Leader>ps` now uses rg as the default search tool instead of ag.
 
 ### Removed
 

--- a/core/autoload/spacevim/autocmd/nerdtree.vim
+++ b/core/autoload/spacevim/autocmd/nerdtree.vim
@@ -73,12 +73,13 @@ function! spacevim#autocmd#nerdtree#Init()
     let g:NERDTreeDirArrowExpandable = ''
     let g:NERDTreeDirArrowCollapsible = ''
   else
-    " ❯
-    let g:NERDTreeDirArrowExpandable = "\u276f"
-    let g:NERDTreeDirArrowCollapsible = "~"
     " ○ ●
     let g:NERDTreeDirArrowExpandable = "\u25cb"
     let g:NERDTreeDirArrowCollapsible = "\u25cf"
+    " ❯
+    " f47c:
+    let g:NERDTreeDirArrowExpandable = "\u276f"
+    let g:NERDTreeDirArrowCollapsible = ""
   endif
 
   let g:NERDTreeIgnore = s:ignore

--- a/core/autoload/spacevim/map/leader.vim
+++ b/core/autoload/spacevim/map/leader.vim
@@ -139,11 +139,13 @@ let s:leader_map['l'] = {
       \ }
 
 let s:leader_map['p'] = {
-      \ 'name' : '+projects'                                ,
-      \ 'f' : ['spacevim#plug#fzf#FindFileInProject()' , 'find-file-in-project']  ,
-      \ 's' : ['Rag'                                        , 'search-in-project']     ,
-      \ 'w' : ['spacevim#plug#fzf#RgCursorWord()', 'find-cword-in-project-via-rg'],
-      \ 'W' : ['spacevim#plug#fzf#SearchCword()'       , 'find-cword-in-project'] ,
+      \ 'name' : '+projects'                           ,
+      \ 'f' : ['spacevim#plug#fzf#FindFileInProject()' , 'find-file-in-project']         ,
+      \ 's' : ['Rg'                                    , 'search-in-project']            ,
+      \ 'a' : ['Rag'                                   , 'search-in-project-via-ag']     ,
+      \ 'r' : ['Rg'                                    , 'search-in-project-via-rg']     ,
+      \ 'w' : ['spacevim#plug#fzf#RgCursorWord()'      , 'find-cword-in-project-via-rg'] ,
+      \ 'W' : ['spacevim#plug#fzf#SearchCword()'       , 'find-cword-in-project']        ,
       \ }
 
 let s:leader_map['r'] = {

--- a/core/autoload/spacevim/plug/fuzzy_finder.vim
+++ b/core/autoload/spacevim/plug/fuzzy_finder.vim
@@ -45,33 +45,59 @@ endfunction
 function! spacevim#plug#fuzzy_finder#fzy.rg() abort
   let s:fuzzy_callback.filename = tempname()
   let s:fuzzy_callback.on_selected = function('s:on_selected_rg')
+
   " --color=always somehow disables the C-J/C-K
   "  TODO: use --color=always should take care of the escape code.
   let choice_cmd = 'rg --column --no-heading --smart-case --line-number ""'
-  let l:term_cmd = choice_cmd . ' | fzy --lines=100 --prompt="fzy> " > ' .  s:fuzzy_callback.filename
+  let l:term_cmd = choice_cmd . ' | fzy --lines=100 --prompt='.s:prompt("fzy> ").' > ' .  s:fuzzy_callback.filename
+
   call s:fuzzy_finder(l:term_cmd)
+
+  syntax match SpaceLinNr /^.*:\zs\d\+\ze:\d\+:/hs=s+1,he=e-1
+  syntax match SpaceColumn /:\d\+:\zs\d\+\ze:/ contains=SpaceLinNr
+  syntax match SpaceLinNrColumn /\zs:\d\+:\d\+:\ze/ contains=SpaceLinNr,SpaceColumn
+  syntax match SpaceFpath /^.*:\d\+:\d\+:/ contains=SpaceLinNrColumn
+
+  highlight default link SpaceFpath       Keyword
+  highlight default link SpaceLinNr       LineNr
+  highlight default link SpaceColumn      Comment
+  highlight default link SpaceLinNrColumn Type
 endfunction
 
 function! spacevim#plug#fuzzy_finder#fzy.rg_files() abort
   let s:fuzzy_callback.filename = tempname()
   let s:fuzzy_callback.on_selected = function('s:on_selected_rg_files')
+
   let choice_cmd = 'rg --no-heading --smart-case --files '.spacevim#util#RootDirectory()
-  let l:term_cmd = choice_cmd . ' | fzy --lines=100 --prompt="fzy> " > ' .  s:fuzzy_callback.filename
-  call s:fuzzy_finder(l:term_cmd)
+  let term_cmd = choice_cmd . ' | fzy --lines=100 --prompt='.s:prompt("fzy> ").' > ' .  s:fuzzy_callback.filename
+
+  call s:fuzzy_finder(term_cmd)
+endfunction
+
+function! s:prompt(default) abort
+  let root_dir = spacevim#util#RootDirectory()
+  return empty(root_dir) ? a:default : root_dir.spacevim#util#PathSep().' '
 endfunction
 
 function! spacevim#plug#fuzzy_finder#skim.rg() abort
   let s:fuzzy_callback.filename = tempname()
   let s:fuzzy_callback.on_selected = function('s:on_selected_rg')
-  let choice_cmd = "sk --layout=reverse --cmd-prompt 'sk> ' --ansi --interactive -c 'rg --smart-case --color=always --column --line-number \"{}\"'"
-  let l:term_cmd = choice_cmd . ' > ' .  s:fuzzy_callback.filename
-  call s:fuzzy_finder(l:term_cmd)
+
+  let prompt = s:prompt('sk> ')
+  let sk_base_cmd = "sk --layout=reverse --cmd-prompt ".s:prompt('sk> ')." --ansi --interactive"
+  let choice_cmd = sk_base_cmd." -c 'rg --smart-case --color=always --column --line-number \"{}\"'"
+  let term_cmd = choice_cmd . ' > ' .  s:fuzzy_callback.filename
+
+  call s:fuzzy_finder(term_cmd)
 endfunction
 
 function! spacevim#plug#fuzzy_finder#skim.rg_files() abort
   let s:fuzzy_callback.filename = tempname()
   let s:fuzzy_callback.on_selected = function('s:on_selected_rg_files')
-  let choice_cmd = "sk --layout=reverse --cmd-prompt 'sk> ' --ansi --interactive -c 'rg --smart-case --color=always --files ".spacevim#util#RootDirectory()." \"{}\"'"
-  let l:term_cmd = choice_cmd . ' > ' .  s:fuzzy_callback.filename
-  call s:fuzzy_finder(l:term_cmd)
+
+  let sk_base_cmd = "sk --layout=reverse --cmd-prompt ".s:prompt('sk> ')." --ansi --interactive"
+  let choice_cmd = sk_base_cmd." -c 'rg --smart-case --color=always --files ".spacevim#util#RootDirectory()." \"{}\"'"
+  let term_cmd = choice_cmd . ' > ' .  s:fuzzy_callback.filename
+
+  call s:fuzzy_finder(term_cmd)
 endfunction

--- a/core/autoload/spacevim/plug/fuzzy_finder.vim
+++ b/core/autoload/spacevim/plug/fuzzy_finder.vim
@@ -70,15 +70,17 @@ function! spacevim#plug#fuzzy_finder#fzy.rg() abort
 
   call s:fuzzy_finder(term_cmd)
 
-  syntax match SpaceLinNr /^.*:\zs\d\+\ze:\d\+:/hs=s+1,he=e-1
-  syntax match SpaceColumn /:\d\+:\zs\d\+\ze:/ contains=SpaceLinNr
-  syntax match SpaceLinNrColumn /\zs:\d\+:\d\+:\ze/ contains=SpaceLinNr,SpaceColumn
-  syntax match SpaceFpath /^.*:\d\+:\d\+:/ contains=SpaceLinNrColumn
+  if has('nvim')
+    syntax match SpaceLinNr /^.*:\zs\d\+\ze:\d\+:/hs=s+1,he=e-1
+    syntax match SpaceColumn /:\d\+:\zs\d\+\ze:/ contains=SpaceLinNr
+    syntax match SpaceLinNrColumn /\zs:\d\+:\d\+:\ze/ contains=SpaceLinNr,SpaceColumn
+    syntax match SpaceFpath /^.*:\d\+:\d\+:/ contains=SpaceLinNrColumn
 
-  highlight default link SpaceFpath       Keyword
-  highlight default link SpaceLinNr       LineNr
-  highlight default link SpaceColumn      Comment
-  highlight default link SpaceLinNrColumn Type
+    highlight default link SpaceFpath       Keyword
+    highlight default link SpaceLinNr       LineNr
+    highlight default link SpaceColumn      Comment
+    highlight default link SpaceLinNrColumn Type
+  endif
 endfunction
 
 function! spacevim#plug#fuzzy_finder#fzy.rg_files() abort

--- a/core/autoload/spacevim/plug/fuzzy_finder.vim
+++ b/core/autoload/spacevim/plug/fuzzy_finder.vim
@@ -63,10 +63,14 @@ function! spacevim#plug#fuzzy_finder#fzy.rg() abort
   let s:fuzzy_callback.filename = tempname()
   let s:fuzzy_callback.on_selected = function('s:on_selected_rg')
 
+  let root_dir = spacevim#util#RootDirectory()
+  let cd = empty(root_dir) ? '' : 'cd '.root_dir
+
   " --color=always somehow disables the C-J/C-K
   "  TODO: use --color=always should take care of the escape code.
-  let choice_cmd = 'rg --column --no-heading --smart-case --line-number ""'
-  let term_cmd = choice_cmd . ' | fzy --lines=100 --prompt='.s:prompt("fzy> ").' > ' .  s:fuzzy_callback.filename
+  let choice_cmd = cd.' && rg --column --no-heading --smart-case --line-number ""'
+  let prompt = s:prompt("fzy> ")
+  let term_cmd = choice_cmd . ' | fzy --lines=100 --prompt='.prompt.' > ' .  s:fuzzy_callback.filename
 
   call s:fuzzy_finder(term_cmd)
 
@@ -87,8 +91,12 @@ function! spacevim#plug#fuzzy_finder#fzy.rg_files() abort
   let s:fuzzy_callback.filename = tempname()
   let s:fuzzy_callback.on_selected = function('s:on_selected_rg_files')
 
-  let choice_cmd = 'rg --no-heading --smart-case --files '.spacevim#util#RootDirectory()
-  let term_cmd = choice_cmd . ' | fzy --lines=100 --prompt='.s:prompt("fzy> ").' > ' .  s:fuzzy_callback.filename
+  let root_dir = spacevim#util#RootDirectory()
+  let cd = empty(root_dir) ? '' : 'cd '.root_dir
+
+  let choice_cmd = cd.' && rg --no-heading --smart-case --files '
+  let prompt = s:prompt("fzy> ")
+  let term_cmd = choice_cmd . ' | fzy --lines=100 --prompt='.prompt.' > ' .  s:fuzzy_callback.filename
 
   call s:fuzzy_finder(term_cmd)
 endfunction
@@ -102,8 +110,11 @@ function! spacevim#plug#fuzzy_finder#skim.rg() abort
   let s:fuzzy_callback.filename = tempname()
   let s:fuzzy_callback.on_selected = function('s:on_selected_rg')
 
+  let root_dir = spacevim#util#RootDirectory()
+  let cd = empty(root_dir) ? '' : 'cd '.root_dir
+
   let prompt = s:prompt('sk> ')
-  let sk_base_cmd = "sk --layout=reverse --cmd-prompt ".s:prompt('sk> ')." --ansi --interactive"
+  let sk_base_cmd = cd." && sk --layout=reverse --cmd-prompt ".prompt." --ansi --interactive"
   let choice_cmd = sk_base_cmd." -c 'rg --smart-case --color=always --column --line-number \"{}\"'"
   let term_cmd = choice_cmd . ' > ' .  s:fuzzy_callback.filename
 
@@ -114,7 +125,11 @@ function! spacevim#plug#fuzzy_finder#skim.rg_files() abort
   let s:fuzzy_callback.filename = tempname()
   let s:fuzzy_callback.on_selected = function('s:on_selected_rg_files')
 
-  let sk_base_cmd = "sk --layout=reverse --cmd-prompt ".s:prompt('sk> ')." --ansi --interactive"
+  let root_dir = spacevim#util#RootDirectory()
+  let cd = empty(root_dir) ? '' : 'cd '.root_dir
+
+  let prompt = s:prompt('sk> ')
+  let sk_base_cmd = cd." && sk --layout=reverse --cmd-prompt ".prompt." --ansi --interactive"
   let choice_cmd = sk_base_cmd." -c 'rg --smart-case --color=always --files ".spacevim#util#RootDirectory()." \"{}\"'"
   let term_cmd = choice_cmd . ' > ' .  s:fuzzy_callback.filename
 

--- a/core/autoload/spacevim/plug/fuzzy_finder.vim
+++ b/core/autoload/spacevim/plug/fuzzy_finder.vim
@@ -1,40 +1,78 @@
 let s:fuzzy_callback = {}
 
+let g:spacevim#plug#fuzzy_finder#fzy = {}
+let g:spacevim#plug#fuzzy_finder#skim = {}
+
+function! s:on_selected_rg_files(selected) abort
+  execute 'edit' a:selected
+endfunction
+
+function! s:on_selected_rg(selected) abort
+  let items = matchlist(a:selected, '^\(\f\+\):\(\d\+\):\(\d\+\):')
+  let fname = items[1]
+  let lnum = items[2]
+  let column = items[3]
+  echom "fname: ".string(fname)
+  execute 'edit' fname
+  call cursor(lnum, column)
+endfunction
+
 function! s:fuzzy_callback.on_exit(job_id, data, event) abort
-    bdelete!
-    call win_gotoid(self.window_id)
+  bdelete!
+  call win_gotoid(self.window_id)
+  try
     if filereadable(self.filename)
-        try
-            let l:selected_filename = readfile(self.filename)[0]
-            exec self.vim_cmd . l:selected_filename
-        catch /E684/
-        endtry
+      try
+        let selected = readfile(self.filename)[0]
+        call s:fuzzy_callback.on_selected(selected)
+      catch /E684/
+      endtry
     endif
-    call delete(self.filename)
+  finally
+    silent! call delete(self.filename)
+  endtry
 endfunction
 
-function! spacevim#plug#fuzzy_finder#fzy(choice_cmd, vim_cmd) abort
+function! s:fuzzy_finder(term_cmd) abort
   let s:fuzzy_callback.window_id = win_getid()
-  let s:fuzzy_callback.filename = tempname()
-  let s:fuzzy_callback.vim_cmd = a:vim_cmd
 
   call spacevim#util#TryFloatingOr()
 
-  let l:term_cmd = a:choice_cmd . ' | fzy > ' .  s:fuzzy_callback.filename
-  silent call termopen(l:term_cmd, s:fuzzy_callback)
+  silent call termopen(a:term_cmd, s:fuzzy_callback)
   setlocal nonumber norelativenumber
   startinsert
 endfunction
 
-function! spacevim#plug#fuzzy_finder#skim(choice_cmd, vim_cmd) abort
-  let s:fuzzy_callback.window_id = win_getid()
+function! spacevim#plug#fuzzy_finder#fzy.rg() abort
   let s:fuzzy_callback.filename = tempname()
-  let s:fuzzy_callback.vim_cmd = a:vim_cmd
+  let s:fuzzy_callback.on_selected = function('s:on_selected_rg')
+  " --color=always somehow disables the C-J/C-K
+  "  TODO: use --color=always should take care of the escape code.
+  let choice_cmd = 'rg --column --no-heading --smart-case --line-number ""'
+  let l:term_cmd = choice_cmd . ' | fzy --lines=100 --prompt="fzy> " > ' .  s:fuzzy_callback.filename
+  call s:fuzzy_finder(l:term_cmd)
+endfunction
 
-  call spacevim#util#TryFloatingOr()
+function! spacevim#plug#fuzzy_finder#fzy.rg_files() abort
+  let s:fuzzy_callback.filename = tempname()
+  let s:fuzzy_callback.on_selected = function('s:on_selected_rg_files')
+  let choice_cmd = 'rg --no-heading --smart-case --files '.spacevim#util#RootDirectory()
+  let l:term_cmd = choice_cmd . ' | fzy --lines=100 --prompt="fzy> " > ' .  s:fuzzy_callback.filename
+  call s:fuzzy_finder(l:term_cmd)
+endfunction
 
-  let l:term_cmd = a:choice_cmd . ' | fzy > ' .  s:fuzzy_callback.filename
-  silent call termopen(l:term_cmd, s:fuzzy_callback)
-  setlocal nonumber norelativenumber
-  startinsert
+function! spacevim#plug#fuzzy_finder#skim.rg() abort
+  let s:fuzzy_callback.filename = tempname()
+  let s:fuzzy_callback.on_selected = function('s:on_selected_rg')
+  let choice_cmd = "sk --layout=reverse --cmd-prompt 'sk> ' --ansi --interactive -c 'rg --smart-case --color=always --column --line-number \"{}\"'"
+  let l:term_cmd = choice_cmd . ' > ' .  s:fuzzy_callback.filename
+  call s:fuzzy_finder(l:term_cmd)
+endfunction
+
+function! spacevim#plug#fuzzy_finder#skim.rg_files() abort
+  let s:fuzzy_callback.filename = tempname()
+  let s:fuzzy_callback.on_selected = function('s:on_selected_rg_files')
+  let choice_cmd = "sk --layout=reverse --cmd-prompt 'sk> ' --ansi --interactive -c 'rg --smart-case --color=always --files ".spacevim#util#RootDirectory()." \"{}\"'"
+  let l:term_cmd = choice_cmd . ' > ' .  s:fuzzy_callback.filename
+  call s:fuzzy_finder(l:term_cmd)
 endfunction

--- a/core/autoload/spacevim/plug/fuzzy_finder.vim
+++ b/core/autoload/spacevim/plug/fuzzy_finder.vim
@@ -1,0 +1,40 @@
+let s:fuzzy_callback = {}
+
+function! s:fuzzy_callback.on_exit(job_id, data, event) abort
+    bdelete!
+    call win_gotoid(self.window_id)
+    if filereadable(self.filename)
+        try
+            let l:selected_filename = readfile(self.filename)[0]
+            exec self.vim_cmd . l:selected_filename
+        catch /E684/
+        endtry
+    endif
+    call delete(self.filename)
+endfunction
+
+function! spacevim#plug#fuzzy_finder#fzy(choice_cmd, vim_cmd) abort
+  let s:fuzzy_callback.window_id = win_getid()
+  let s:fuzzy_callback.filename = tempname()
+  let s:fuzzy_callback.vim_cmd = a:vim_cmd
+
+  call spacevim#util#TryFloatingOr()
+
+  let l:term_cmd = a:choice_cmd . ' | fzy > ' .  s:fuzzy_callback.filename
+  silent call termopen(l:term_cmd, s:fuzzy_callback)
+  setlocal nonumber norelativenumber
+  startinsert
+endfunction
+
+function! spacevim#plug#fuzzy_finder#skim(choice_cmd, vim_cmd) abort
+  let s:fuzzy_callback.window_id = win_getid()
+  let s:fuzzy_callback.filename = tempname()
+  let s:fuzzy_callback.vim_cmd = a:vim_cmd
+
+  call spacevim#util#TryFloatingOr()
+
+  let l:term_cmd = a:choice_cmd . ' | fzy > ' .  s:fuzzy_callback.filename
+  silent call termopen(l:term_cmd, s:fuzzy_callback)
+  setlocal nonumber norelativenumber
+  startinsert
+endfunction

--- a/core/autoload/spacevim/plug/fuzzy_finder.vim
+++ b/core/autoload/spacevim/plug/fuzzy_finder.vim
@@ -12,7 +12,6 @@ function! s:on_selected_rg(selected) abort
   let fname = items[1]
   let lnum = items[2]
   let column = items[3]
-  echom "fname: ".string(fname)
   execute 'edit' fname
   call cursor(lnum, column)
 endfunction

--- a/core/autoload/spacevim/plug/fzf.vim
+++ b/core/autoload/spacevim/plug/fzf.vim
@@ -1,36 +1,6 @@
 let s:has_floating_win = exists('*nvim_open_win')
 let g:fzf_layout = get(g:, 'fzf_layout', {'down': '~40%'})
 
-function! spacevim#plug#fzf#FloatingWin()
-  let height = &lines - 3
-  let width = float2nr(&columns - (&columns * 2 / 10))
-  let col = float2nr((&columns - width) / 2)
-
-  let col_offset = &columns / 6
-
-  let opts = {
-        \ 'relative': 'editor',
-        \ 'row': height * 0.3,
-        \ 'col': col + col_offset,
-        \ 'width': width * 2 / 3,
-        \ 'height': height / 2
-        \ }
-
-  let buf = nvim_create_buf(v:false, v:true)
-
-  let win = nvim_open_win(buf, v:true, opts)
-
-  call setwinvar(win, '&winhl', 'Normal:Pmenu')
-
-  setlocal
-        \ buftype=nofile
-        \ nobuflisted
-        \ bufhidden=hide
-        \ nonumber
-        \ norelativenumber
-        \ signcolumn=no
-endfunction
-
 function! s:fzf(name, opts, extra)
   call spacevim#plug#fzf_base#Run(a:name, a:opts, a:extra)
 endfunction

--- a/core/autoload/spacevim/plug/fzf.vim
+++ b/core/autoload/spacevim/plug/fzf.vim
@@ -203,11 +203,12 @@ function! spacevim#plug#fzf#Rg(query, bang) abort
     return spacevim#util#warn('rg is not found')
   endif
   echo "\r"
+  let preview_opts = a:bang ? fzf#vim#with_preview('up:60%') : fzf#vim#with_preview('right:50%:hidden', '?')
+  call extend(preview_opts.options, ['--prompt', spacevim#util#RootDirectory().'> '])
   call fzf#vim#grep(
         \ 'rg --column --line-number --no-heading --color=always --smart-case '.shellescape(a:query), 1,
-        \ a:bang ? fzf#vim#with_preview('up:60%')
-        \        : fzf#vim#with_preview('right:50%:hidden', '?'),
-        \ a:bang
+        \ preview_opts,
+        \ a:bang,
         \ )
 endfunction
 

--- a/core/autoload/spacevim/util.vim
+++ b/core/autoload/spacevim/util.vim
@@ -178,7 +178,7 @@ function! spacevim#util#TryFloatingOr()
   if exists('*nvim_open_win')
     call spacevim#util#FloatingWin()
   else
-    botright 30 new
+    botright 15 new
   endif
 endfunction
 

--- a/core/autoload/spacevim/util.vim
+++ b/core/autoload/spacevim/util.vim
@@ -143,3 +143,41 @@ function! spacevim#util#Getfsize(fname) abort
   endif
   return size
 endfunction
+
+function! spacevim#util#FloatingWin() abort
+  let height = &lines - 3
+  let width = float2nr(&columns - (&columns * 2 / 10))
+  let col = float2nr((&columns - width) / 2)
+
+  let col_offset = &columns / 6
+
+  let opts = {
+        \ 'relative': 'editor',
+        \ 'row': height * 0.3,
+        \ 'col': col + col_offset,
+        \ 'width': width * 2 / 3,
+        \ 'height': height / 2
+        \ }
+
+  let buf = nvim_create_buf(v:false, v:true)
+
+  let win = nvim_open_win(buf, v:true, opts)
+
+  call setwinvar(win, '&winhl', 'Normal:Pmenu')
+
+  setlocal
+        \ buftype=nofile
+        \ nobuflisted
+        \ bufhidden=hide
+        \ nonumber
+        \ norelativenumber
+        \ signcolumn=no
+endfunction
+
+function! spacevim#util#TryFloatingOr()
+  if exists('*nvim_open_win')
+    call spacevim#util#FloatingWin()
+  else
+    botright 30 new
+  endif
+endfunction

--- a/core/autoload/spacevim/util.vim
+++ b/core/autoload/spacevim/util.vim
@@ -181,3 +181,7 @@ function! spacevim#util#TryFloatingOr()
     botright 30 new
   endif
 endfunction
+
+function! spacevim#util#PathSep() abort
+  return g:spacevim.os.windows ? '\' : '/'
+endfunction

--- a/layers/+tools/fzf/config.vim
+++ b/layers/+tools/fzf/config.vim
@@ -16,7 +16,7 @@ else
 
   if exists('*nvim_open_win')
     let $FZF_DEFAULT_OPTS = '--layout=reverse'
-    let g:fzf_layout = { 'window': 'call spacevim#plug#fzf#FloatingWin()' }
+    let g:fzf_layout = { 'window': 'call spacevim#util#FloatingWin()' }
   else
     " g:fzf_colors would reset the highlight even you have set the highlight
     " of floating window explicitly.
@@ -39,16 +39,21 @@ else
                 \   }
   endif
 
-  " fzf.vim doesn't enable preview feature by default.
-  command! -bang -nargs=* Ag
-              \ echo "\r" | call fzf#vim#ag(<q-args>, fzf#vim#with_preview(), <bang>0)
+  if get(g:, 'spacevim_prefer_skim', 0)
+    command! -bang -nargs=* Ag call fzf#vim#ag_interactive(<q-args>, fzf#vim#with_preview('right:50%:hidden', 'alt-h'))
+    command! -bang -nargs=* Rg call fzf#vim#rg_interactive(<q-args>, fzf#vim#with_preview('right:50%:hidden', 'alt-h'))
+  else
+    " fzf.vim doesn't enable preview feature by default.
+    command! -bang -nargs=* Ag
+                \ echo "\r" | call fzf#vim#ag(<q-args>, fzf#vim#with_preview(), <bang>0)
 
-  command! -bang -nargs=? -complete=dir Files
-    \ echo "\r\r" | call fzf#vim#files(<q-args>, fzf#vim#with_preview(), <bang>0)
+    command! -bang -nargs=? -complete=dir Files
+      \ echo "\r\r" | call fzf#vim#files(<q-args>, fzf#vim#with_preview(), <bang>0)
 
-  command! -nargs=* Rag call spacevim#plug#fzf#AgInProject(<q-args>)
+    command! -nargs=* Rag call spacevim#plug#fzf#AgInProject(<q-args>)
 
-  command! -bang -nargs=* Rg call spacevim#plug#fzf#Rg(<q-args>, <bang>0)
+    command! -bang -nargs=* Rg call spacevim#plug#fzf#Rg(<q-args>, <bang>0)
+  endif
 
   nmap <Leader>? <plug>(fzf-maps-n)
   xmap <Leader>? <plug>(fzf-maps-x)

--- a/layers/+tools/fzf/config.vim
+++ b/layers/+tools/fzf/config.vim
@@ -39,21 +39,16 @@ else
                 \   }
   endif
 
-  if get(g:, 'spacevim_prefer_skim', 0)
-    command! -bang -nargs=* Ag call fzf#vim#ag_interactive(<q-args>, fzf#vim#with_preview('right:50%:hidden', 'alt-h'))
-    command! -bang -nargs=* Rg call fzf#vim#rg_interactive(<q-args>, fzf#vim#with_preview('right:50%:hidden', 'alt-h'))
-  else
-    " fzf.vim doesn't enable preview feature by default.
-    command! -bang -nargs=* Ag
-                \ echo "\r" | call fzf#vim#ag(<q-args>, fzf#vim#with_preview(), <bang>0)
+  " fzf.vim doesn't enable preview feature by default.
+  command! -bang -nargs=* Ag
+              \ echo "\r" | call fzf#vim#ag(<q-args>, fzf#vim#with_preview(), <bang>0)
 
-    command! -bang -nargs=? -complete=dir Files
-      \ echo "\r\r" | call fzf#vim#files(<q-args>, fzf#vim#with_preview(), <bang>0)
+  command! -bang -nargs=? -complete=dir Files
+    \ echo "\r\r" | call fzf#vim#files(<q-args>, fzf#vim#with_preview(), <bang>0)
 
-    command! -nargs=* Rag call spacevim#plug#fzf#AgInProject(<q-args>)
+  command! -nargs=* Rag call spacevim#plug#fzf#AgInProject(<q-args>)
 
-    command! -bang -nargs=* Rg call spacevim#plug#fzf#Rg(<q-args>, <bang>0)
-  endif
+  command! -bang -nargs=* Rg call spacevim#plug#fzf#Rg(<q-args>, <bang>0)
 
   nmap <Leader>? <plug>(fzf-maps-n)
   xmap <Leader>? <plug>(fzf-maps-x)

--- a/layers/+tools/fzf/packages.vim
+++ b/layers/+tools/fzf/packages.vim
@@ -2,21 +2,11 @@ if g:spacevim.gui && !has('terminal')
   MP 'Yggdroot/LeaderF'
 else
   if g:spacevim.speed_up_via_timer
-    if get(g:, 'spacevim_prefer_skim', 0)
-      MP 'lotabout/skim', { 'dir': '~/.skim', 'do': './install' }
-      MP 'lotabout/skim.vim'
-    else
-      MP 'junegunn/fzf',  { 'dir': '~/.fzf', 'do': './install --all', 'on': [] }
-      MP 'junegunn/fzf.vim', { 'on': [] }
-      call timer_start(700, 'spacevim#defer#fzf')
-    endif
+    MP 'junegunn/fzf',  { 'dir': '~/.fzf', 'do': './install --all', 'on': [] }
+    MP 'junegunn/fzf.vim', { 'on': [] }
+    call timer_start(700, 'spacevim#defer#fzf')
   else
-    if get(g:, 'spacevim_prefer_skim', 0)
-      MP 'lotabout/skim', { 'dir': '~/.skim', 'do': './install' }
-      MP 'lotabout/skim.vim'
-    else
-      MP 'junegunn/fzf',  { 'dir': '~/.fzf', 'do': './install --all' }
-      MP 'junegunn/fzf.vim'
-    endif
+    MP 'junegunn/fzf',  { 'dir': '~/.fzf', 'do': './install --all' }
+    MP 'junegunn/fzf.vim'
   endif
 endif

--- a/layers/+tools/fzf/packages.vim
+++ b/layers/+tools/fzf/packages.vim
@@ -2,11 +2,21 @@ if g:spacevim.gui && !has('terminal')
   MP 'Yggdroot/LeaderF'
 else
   if g:spacevim.speed_up_via_timer
-    MP 'junegunn/fzf',  { 'dir': '~/.fzf', 'do': './install --all', 'on': [] }
-    MP 'junegunn/fzf.vim', { 'on': [] }
-    call timer_start(700, 'spacevim#defer#fzf')
+    if get(g:, 'spacevim_prefer_skim', 0)
+      MP 'lotabout/skim', { 'dir': '~/.skim', 'do': './install' }
+      MP 'lotabout/skim.vim'
+    else
+      MP 'junegunn/fzf',  { 'dir': '~/.fzf', 'do': './install --all', 'on': [] }
+      MP 'junegunn/fzf.vim', { 'on': [] }
+      call timer_start(700, 'spacevim#defer#fzf')
+    endif
   else
-    MP 'junegunn/fzf',  { 'dir': '~/.fzf', 'do': './install --all' }
-    MP 'junegunn/fzf.vim'
+    if get(g:, 'spacevim_prefer_skim', 0)
+      MP 'lotabout/skim', { 'dir': '~/.skim', 'do': './install' }
+      MP 'lotabout/skim.vim'
+    else
+      MP 'junegunn/fzf',  { 'dir': '~/.fzf', 'do': './install --all' }
+      MP 'junegunn/fzf.vim'
+    endif
   endif
 endif


### PR DESCRIPTION
Windows is unsupported. Example usage:

```vim
command! Fzy call spacevim#plug#fuzzy_finder#fzy.rg()
command! Skim call spacevim#plug#fuzzy_finder#skim.rg()
```
