### PR TITLE
Enable vim-lsp for Python

### DIFF
--- a/core/autoload/spacevim/lang/lsp.vim
+++ b/core/autoload/spacevim/lang/lsp.vim
@@ -14,3 +14,11 @@ function! spacevim#lang#lsp#register_go() abort
           \ 'whitelist': ['go'],
           \ })
 endfunction
+
+function! spacevim#lang#lsp#register_python() abort
+  call lsp#register_server({
+          \ 'name': 'pyls',
+          \ 'cmd': {server_info->['pyls']},
+          \ 'whitelist': ['python'],
+          \ })
+endfunction

--- a/layers/+completion/asyncomplete/README.md
+++ b/layers/+completion/asyncomplete/README.md
@@ -1,0 +1,17 @@
+# Asyncomplete layer
+
+## Table of Contents
+
+<!-- vim-markdown-toc GFM -->
+* [Description](#description)
+* [Install](#install)
+
+<!-- vim-markdown-toc -->
+
+## Description
+
+This layer adds support for asyncomplete.
+
+## Install
+
+To use this configuration layer, add it to your `~/.spacevim`.

--- a/layers/+completion/asyncomplete/config.vim
+++ b/layers/+completion/asyncomplete/config.vim
@@ -1,0 +1,18 @@
+inoremap <expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"
+inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
+inoremap <expr> <cr>    pumvisible() ? "\<C-y>" : "\<cr>"
+
+let g:asyncomplete_auto_popup = 0
+
+function! s:check_back_space() abort
+    let col = col('.') - 1
+    return !col || getline('.')[col - 1]  =~ '\s'
+endfunction
+
+inoremap <silent><expr> <TAB>
+  \ pumvisible() ? "\<C-n>" :
+  \ <SID>check_back_space() ? "\<TAB>" :
+  \ asyncomplete#force_refresh()
+inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
+
+autocmd! CompleteDone * if pumvisible() == 0 | pclose | endif

--- a/layers/+completion/asyncomplete/packages.vim
+++ b/layers/+completion/asyncomplete/packages.vim
@@ -1,0 +1,2 @@
+MP 'prabirshrestha/asyncomplete.vim'
+MP 'prabirshrestha/asyncomplete-lsp.vim'

--- a/layers/+tools/lsp/config.vim
+++ b/layers/+tools/lsp/config.vim
@@ -109,6 +109,9 @@ function! s:vim_lsp() abort
   if executable('go-langserver')
     autocmd User lsp_setup call spacevim#lang#lsp#register_go()
   endif
+  if executable('pyls')
+    autocmd User lsp_setup call spacevim#lang#lsp#register_python()
+  endif
 endfunction
 
 call s:{g:spacevim_lsp_engine}()

--- a/layers/+tools/lsp/config.vim
+++ b/layers/+tools/lsp/config.vim
@@ -103,6 +103,7 @@ function! s:lcn() abort
 endfunction
 
 function! s:vim_lsp() abort
+  let g:lsp_diagnostics_enabled = 0
   if executable('rls')
     autocmd User lsp_setup call spacevim#lang#lsp#register_rls()
   endif

--- a/layers/+tools/lsp/packages.vim
+++ b/layers/+tools/lsp/packages.vim
@@ -11,6 +11,7 @@ endfunction
 function! s:vim_lsp() abort
   MP 'prabirshrestha/async.vim'
   MP 'prabirshrestha/vim-lsp'
+  MP 'mattn/vim-lsp-settings'
 endfunction
 
 function! s:lcn() abort


### PR DESCRIPTION
Add vim-lsp configuration for Python to the code. Also add asyncomplete as another option for completion. 

vim-lsp works for Python with this change. 