### PR TITLE
Add empty query check to Grep

### DIFF
--- a/core/autoload/spacevim/vim/grep.vim
+++ b/core/autoload/spacevim/vim/grep.vim
@@ -15,15 +15,17 @@ endif
 function! spacevim#vim#grep#Grep(query)
   let grepprg = &l:grepprg
   let grepformat = &l:grepformat
-  " https://github.com/mileszs/ack.vim/issues/18
   let shellpipe = &l:shellpipe
   let &l:shellpipe = '>'
   let &l:grepprg = s:grep.prg
   let &l:grepformat = s:grep.format
-  " https://github.com/mileszs/ack.vim/issues/5
-  execute 'silent! grep! '.shellescape(fnameescape(a:query))
+  if a:query ==# ''
+    echomsg 'no query passed to grep, exiting'
+  else
+    execute 'silent! grep! '.shellescape(fnameescape(a:query))
+    redraw!
+  endif
   let &l:grepprg = grepprg
   let &l:grepformat = grepformat
   let &l:shellpipe = shellpipe
-  redraw!
 endfunction


### PR DESCRIPTION
I accidentally froze up my entire vim session, then subsequently also my computer session by accidentally executing `:Grep` without passing a query. I came over from using [Grepper](https://github.com/mhinz/vim-grepper), which required executing `:Grepper` alone to initiate a grepping search, so it must have been muscle memory.

Figured others likely also ran into (or will continue to run into) this problem too, hence this quick and dirty fix.