### PR TITLE
Use glob instead of os.listdir in s:py_init

### DIFF
--- a/core/autoload/spacevim/cache.vim
+++ b/core/autoload/spacevim/cache.vim
@@ -51,17 +51,21 @@ function! s:py_init()
 execute s:py_exe "<< EOF"
 import os
 import vim
+from glob import glob
+
+def glob_basename(path):
+    return map(os.path.basename, glob(path + '/*'))
 
 spacevim_base = vim.eval('g:spacevim.base')
 topic_base = spacevim_base + vim.eval('g:spacevim.layers_base')
 private_base = spacevim_base + vim.eval('g:spacevim.private_base')
 
 topics_path = [
-    os.path.join(topic_base, f) for f in os.listdir(topic_base)
+    os.path.join(topic_base, f) for f in glob_basename(topic_base)
     if os.path.isdir(os.path.join(topic_base, f))
 ]
 private = [
-    f for f in os.listdir(private_base)
+    f for f in glob_basename(private_base)
     if os.path.isdir(os.path.join(private_base, f))
 ]
 
@@ -70,7 +74,7 @@ spacevim_manifest = {}
 
 for topic in topics_path:
     layers = [
-        f for f in os.listdir(topic) if os.path.isdir(os.path.join(topic, f))
+        f for f in glob_basename(topic) if os.path.isdir(os.path.join(topic, f))
     ]
     spacevim_topics[os.path.split(topic)[-1]] = layers
     for layer in layers:


### PR DESCRIPTION
Since I began using git to track my personal configuration inside of `~/.space-vim/private/`, I'd sometimes run into this weird misbehavior where upon starting `$ nvim`, it'd be blocked by vim echoing messages like shown in the screenshot below:
![image](https://user-images.githubusercontent.com/12605746/100494160-06010c80-310d-11eb-978b-5ead668b85ab.png)

This required me to press enter in order to start using the editor. Functionally it's not a huge deal, but can nonetheless be a bit unpleasant to deal with. And indeed, inside vim, `:echo g:spacevim.private` showed `['.git']`.

The thing that I found really strange was that this problem would only happen occasionally. Upon investigation, it turned to be caused by the slight difference in behavior b/w `s:init` and `s:py_init` in the `cache.vim` script. The former uses `globpath` to obtain the contents of a given directory, which much like a Unix shell glob, ignores hidden files and dirs; while the latter uses `os.listdir`, which includes hidden files and dirs as part of its return.

For my purposes of ensuring space-vim ignores the `.git` directory under `private/`, it was enough to just do something like:
`private = [f for f in os.listdir(private_base) if os.path.isdir(os.path.join(private_base, f)) and not f.startswith('.')]` (the last conditional checking a file not starting with `.` would be enough to fix my problem).

But I thought it better to make the behavior of both `s:init` and `s:py_init` uniform wrt globbing, hence this PR.