### PR TITLE
missing virtualTexthl breaks lcn

### DIFF
--- a/layers/+tools/lsp/config.vim
+++ b/layers/+tools/lsp/config.vim
@@ -79,24 +79,28 @@ function! s:lcn() abort
   \            "texthl": "Error",
   \            "signText": "✖",
   \            "signTexthl": "ErrorMsg",
+  \            "virtualTexthl": "ErrorMsg",
   \        },
   \        2: {
   \            "name": "Warning",
   \            "texthl": "Warning",
   \            "signText": "⚠",
   \            "signTexthl": "WarningMsg",
+  \            "virtualTexthl": "WarningMsg",
   \        },
   \        3: {
   \            "name": "Information",
   \            "texthl": "Type",
   \            "signText": "ℹ",
   \            "signTexthl": "Type",
+  \            "virtualTexthl": "Type",
   \        },
   \        4: {
   \            "name": "Hint",
   \            "texthl": "String",
   \            "signText": "➤",
   \            "signTexthl": "String",
+  \            "virtualTexthl": "String",
   \        },
   \    }
 


### PR DESCRIPTION
This is a minor change to add highlight groups in the `LanguageClient-neovim` configuration. The absence of these was leading to the various language servers to exit silently (or maybe not even starting), effectively breaking the plugin for me. Adding these four lines fixed 🤷

Let me know if there's anything else you need from me in order to merge. 👍 