### PR TITLE
Use new vim-fugitive commands

### DIFF
--- a/layers/+version-control/git/config.vim
+++ b/layers/+version-control/git/config.vim
@@ -2,10 +2,10 @@ scriptencoding utf-8
 
 " vim-fugitive {
   nnoremap <silent> <Leader>gs :Gstatus<CR>
-  nnoremap <silent> <Leader>gd :Gdiff<CR>
-  nnoremap <silent> <Leader>gc :Gcommit<CR>
-  nnoremap <silent> <Leader>gb :Gblame<CR>
-  nnoremap <silent> <Leader>gl :Glog<CR>
+  nnoremap <silent> <Leader>gd :Gdiffsplit<CR>
+  nnoremap <silent> <Leader>gc :Git commit<CR>
+  nnoremap <silent> <Leader>gb :Git blame<CR>
+  nnoremap <silent> <Leader>gl :Gclog<CR>
   nnoremap <silent> <Leader>gp :Git push<CR>
   nnoremap <silent> <Leader>gr :Gread<CR>
   nnoremap <silent> <Leader>gw :Gwrite<CR>


### PR DESCRIPTION
The following fugitive commands have been deprecated in favor of new ones:

```
:Gdiff -> :Gdiffsplit
:Gcommit -> :Git commit
:Gblame -> :Git blame
:Glog -> :Gclog
```