### PR TITLE
Make space-vim able to be installed to location other than ~/.space-vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,10 @@ Thumbs.db
 
 tags
 
+autoload/plug.vim
 core/autoload/info.vim
 core/autoload/spacevim/info.vim
+plugged/*
 *.un~
 private/*
 !private/README.md

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
+PWD           := $(shell pwd)
 APP           := space-vim
-INIT_VIM      := ~/.space-vim/init.vim
+INIT_VIM      := $(PWD)/init.vim
 VIMRC         := ~/.vimrc
 NVIMRC        := ~/.config/nvim/init.vim
 
-INIT_SPACEVIM := ~/.space-vim/init.spacevim
+INIT_SPACEVIM := $(PWD)/init.spacevim
 DOT_SPACEVIM  := ~/.spacevim
 
 help:
@@ -39,7 +40,6 @@ uninstall:
 	rm -f  $(VIMRC)            && echo "    - Removed $(VIMRC)"; \
 	rm -f  $(NVIMRC)           && echo "    - Removed $(NVIMRC)"; \
 	rm -f  $(DOT_SPACEVIM)     && echo "    - Removed $(DOT_SPACEVIM)"; \
-	rm -rf ~/.$(APP)           && echo "    - Removed ~/.$(APP)"; \
 	echo -e "\033[32m[✔]\033[0m Successfully uninstalled $(APP)"
 
 .PHONY: help vim neovim update uninstall

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ $ bash <(curl -fsSL https://raw.githubusercontent.com/liuchengxu/space-vim/maste
 #### Makefile
 
 ```bash
-$ git clone https://github.com/liuchengxu/space-vim.git ~/.space-vim
-$ cd ~/.space-vim
+$ git clone https://github.com/liuchengxu/space-vim.git /path/to/space-vim
+$ cd /path/to/space-vim
 $ make vim     # install space-vim for Vim
 $ make neovim  # install space-vim for NeoVim
 ```
@@ -123,30 +123,39 @@ The easist way is to download [`install.cmd`](https://raw.githubusercontent.com/
 
 Given git and Vim/NeoVim have been installed already:
 
-1. Clone [space-vim](https://github.com/liuchengxu/space-vim)
+1. Clone [space-vim](https://github.com/liuchengxu/space-vim):
+
+    /path/to/space-vim may be ~/.vim or ~/.config/nvіm if you so desire.
 
     ```bash
-    $ git clone https://github.com/liuchengxu/space-vim.git ~/.space-vim
+    $ git clone https://github.com/liuchengxu/space-vim.git /path/to/space-vim
     ```
 
-2. Install [vim-plug](https://github.com/junegunn/vim-plug#installation), refer to vim-plug installation section for more information.
+2. Install [vim-plug](https://github.com/junegunn/vim-plug#installation), refer to vim-plug installation section for more information:
+    ```bash
+    # For Vim
+    $ curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+        https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+    # For NeoVim
+    sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
+           https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+    ```
 
-3. Create the symlinks.
+3. Create the symlinks and install plugins:
 
     **Linux and macOS**
 
     ```bash
     # For Vim
-    $ ln -s ~/.space-vim/init.vim ~/.vimrc
+    $ ln -s /path/to/space-vim/init.vim ~/.vimrc
+    $ cp /path/to/space-vim/init.spacevim ~/.spacevim
+    $ vim -es +'PlugInstall' +qall
 
     # For NeoVim
-    $ ln -s ~/.space-vim/init.vim ~/.config/nvim/init.vim
-
-    # Both for Vim and NeoVim
-    $ cp ~/.space-vim/init.spacevim ~/.spacevim
+    $ ln -s /path/to/space-vim/init.vim ~/.config/nvim/init.vim
+    $ cp /path/to/space-vim/init.spacevim ~/.spacevim
+    $ nvim +'PlugInstall' +qall
     ```
-
-5. Open vim, then space-vim will automatically detect and install the missing plugins. If auto-installation fails unexpectly, please try running `:PlugInstall` manually.
 
 ## Customize
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Given git and Vim/NeoVim have been installed already:
     # For Vim
     $ curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
         https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+        
     # For NeoVim
     sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
            https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Given git and Vim/NeoVim have been installed already:
 
 1. Clone [space-vim](https://github.com/liuchengxu/space-vim):
 
-    /path/to/space-vim may be ~/.vim or ~/.config/nvіm if you so desire.
+    `/path/to/space-vim` may be `~/.vim` or `~/.config/nvіm` if you so desire.
 
     ```bash
     $ git clone https://github.com/liuchengxu/space-vim.git /path/to/space-vim

--- a/core/autoload/spacevim/autocmd/unite.vim
+++ b/core/autoload/spacevim/autocmd/unite.vim
@@ -101,7 +101,7 @@ let s:menus.v = {
             \}
 let s:menus.v.command_candidates = [
             \['►   init.vim',
-            \'e ~/.vimrc'],
+            \'e '.g:spacevim.base.'/init.vim'],
             \['►   .spacevim',
             \'e ~/.spacevim'],
             \['►   vim-help',

--- a/core/autoload/spacevim/map/manager.vim
+++ b/core/autoload/spacevim/map/manager.vim
@@ -2,7 +2,7 @@ let s:clap_enabled = get(g:, 'spacevim_enable_clap', 0)
 
 let g:spacevim#map#manager#quick_open = [
         \ '~/.spacevim',
-        \ '~/.space-vim/init.vim',
+        \ g:spacevim.base.'/init.vim',
         \ '~/.bashrc',
         \ '~/.zshrc',
         \ '~/.tmux.conf',

--- a/init.vim
+++ b/init.vim
@@ -17,7 +17,7 @@
 scriptencoding utf-8
 
 let g:spacevim = get(g:, 'spacevim', {})
-let g:spacevim.base = $HOME.'/.space-vim'
+let g:spacevim.base = fnamemodify(resolve(expand('<sfile>:p')),':h')
 let g:spacevim.version = '0.9.0'
 
 " Identify platform {
@@ -35,6 +35,6 @@ if g:spacevim.os.windows
 endif
 " }
 
-set runtimepath+=$HOME/.space-vim/core
+let &runtimepath = &runtimepath . ',' . g:spacevim.base . '/core'
 
 call spacevim#bootstrap()

--- a/layers/+tools/lsp/config.vim
+++ b/layers/+tools/lsp/config.vim
@@ -60,7 +60,7 @@ function! s:lcn() abort
   let g:LanguageClient_loggingFile = '/tmp/LanguageClient.log'
   let g:LanguageClient_loggingLevel = 'INFO'
   let g:LanguageClient_serverStderr = '/tmp/LanguageServer.log'
-  let g:LanguageClient_settingsPath = expand('~/.space-vim/layers/+tools/lsp/settings.json')
+  let g:LanguageClient_settingsPath = fnamemodify(resolve(expand('<sfile>:p')),':h').'/settings.json'
 
   let g:LanguageClient_serverCommands = {
         \ 'c': ['ccls', '--log-file=/tmp/cq.log'],


### PR DESCRIPTION
Fixes #472.

New Bug: layers/layers.py has incorrect path to info.vim
But I suppose this isn't a big issue as layers/layers.py appears to be a helper script which generates https://github.com/liuchengxu/space-vim/blob/master/layers/LAYERS.md, which is something I imagine only the maintainer does, and not an end-user.

From my understanding this python script doesn't have access to g:spacevim.base (in vimscript). A fix I can think of off the top of my head would be to store info.vim in a cache directory, accessible from an environmental variable like $XDG_RUNTIME_DIR/vim or $TMPDIR/vim-$USER, But, such a fix would be outside the scope of this commit. Another possible fix would be a check in python verifying the the installation is to ~/.space-vim

**EDIT:** Altered the .gitignore in order to better facilitate /path/to/spacevim being ~/.vim if the end-user chooses that install location.