### PR TITLE
Speedup, only run helptags core/doc when necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tags
 autoload/plug.vim
 core/autoload/info.vim
 core/autoload/spacevim/info.vim
+core/doc/.spacevim_last_helptags_run
 plugged/*
 *.un~
 private/*

--- a/core/autoload/spacevim.vim
+++ b/core/autoload/spacevim.vim
@@ -145,11 +145,18 @@ function! spacevim#end() abort
   call s:config()
   if exists('*UserConfig') | call UserConfig() | endif
 
-  try
-    execute 'helptags' g:spacevim.base . '/core/doc'
-  catch
-    echom v:exception
-  endtry
+  let helptag_file = g:spacevim.base . '/core/doc/spacevim.txt'
+  let helptag_time = getftime(helptag_file)
+  let helptag_lastrun_file = g:spacevim.base . '/core/doc/.spacevim_last_helptags_run'
+  let helptag_lastrun_time = filereadable(helptag_lastrun_file) ? readfile(helptag_lastrun_file) : []
+  if (len(helptag_lastrun_time) != 1) || (helptag_lastrun_time[0] != helptag_time)
+    try
+      execute 'helptags' g:spacevim.base . '/core/doc'
+      call writefile([helptag_time], helptag_lastrun_file)
+    catch
+      echom v:exception
+    endtry
+  endif
 
   call s:check_missing_plugins()
   silent doautocmd <nomodeline> User SpacevimAfterUserConfig


### PR DESCRIPTION
Allows for faster launch.

Stores the last modified time of `core/doc/spacevim.txt` in a file named `.spacevim_lastprocessed`. When `spacevim.txt` is updated, the logic will re-run helptags and update `.spacevim_lastprocessed`.

Faster than running helptags to regenerate the `core/doc/tags` file each launch, which is a slow operation on my ext4 filesystem on a flashdrive. In addition this is a source of error messages when sandboxing (making ~/.vim readonly).