### PR TITLE
Remove installation screen clutter

### DIFF
--- a/layers/+tools/lsp/packages.vim
+++ b/layers/+tools/lsp/packages.vim
@@ -17,8 +17,16 @@ endfunction
 function! s:lcn() abort
   MP 'autozimu/LanguageClient-neovim', {
     \ 'branch': 'next',
-    \ 'do': 'bash install.sh',
+    \ 'do': function('Install_LanguageClient_neovim'),
     \ }
+endfunction
+
+function! Install_LanguageClient_neovim(info)
+  if spacevim#load('programming')
+    execute('AsyncRun -mode=term -pos=tab @ bash install.sh')
+  else
+    execute('bash install.sh')
+  endif
 endfunction
 
 let g:spacevim_lsp_engine = get(g:, 'spacevim_lsp_engine', 'lcn')


### PR DESCRIPTION
Using AsyncRun to install things in vim-plug `:PlugInstall` post-update hooks will prevent the screen from messing up and being left unreadable.

This fixes one instance of the problem in the lsp layer.