### PR TITLE
Add base which-key visual description dictionaries

### DIFF
--- a/core/autoload/spacevim/autocmd/which_key.vim
+++ b/core/autoload/spacevim/autocmd/which_key.vim
@@ -1,4 +1,6 @@
 function! spacevim#autocmd#which_key#Init() abort
-  call which_key#register('<Space>', 'g:spacevim#map#leader#desc')
-  call which_key#register(',', 'g:spacevim#map#localleader#desc')
+  call which_key#register('<Space>', 'g:spacevim#map#leader#desc', 'n')
+  call which_key#register(',', 'g:spacevim#map#localleader#desc', 'n')
+  call which_key#register('<Space>', 'g:spacevim#map#leader#desc_visual', 'v')
+  call which_key#register(',', 'g:spacevim#map#localleader#desc_visual', 'v')
 endfunction

--- a/core/autoload/spacevim/map/leader.vim
+++ b/core/autoload/spacevim/map/leader.vim
@@ -207,3 +207,8 @@ let s:leader_map['x'] = {
       \ }
 
 let g:spacevim#map#leader#desc =  get(g:, 'spacevim#map#leader#desc', s:leader_map)
+
+let s:leader_map_visual =  {}
+let s:leader_map_visual['name'] = 'space-vim root'
+
+let g:spacevim#map#leader#desc_visual =  get(g:, 'spacevim#map#leader#desc_visual', s:leader_map_visual)

--- a/core/autoload/spacevim/map/localleader.vim
+++ b/core/autoload/spacevim/map/localleader.vim
@@ -9,3 +9,7 @@ let s:localleader_map['f'] = {
       \ }
 
 let g:spacevim#map#localleader#desc = get(g:, 'g:spacevim#map#localleader#desc', s:localleader_map)
+
+let s:localleader_map_visual = {}
+
+let g:spacevim#map#localleader#desc_visual = get(g:, 'g:spacevim#map#localleader#desc_visual', s:localleader_map_visual)


### PR DESCRIPTION
Here are base visual vim-which-key description dictionaries.

For use with vim-which-key addition of [separate visual dictionaries](https://github.com/liuchengxu/vim-which-key/pull/213).

I have some vim-lsp changes and the C# layer which use this change.

**Contingent on:** [vim-which-key#213](https://github.com/liuchengxu/vim-which-key/pull/213)