### PR TITLE
Add C# language layer

### DIFF
--- a/core/ftplugin/cs.vim
+++ b/core/ftplugin/cs.vim
@@ -1,0 +1,67 @@
+if exists('b:did_spacevim_cs_ftplugin') || !spacevim#load('csharp')
+  finish
+endif
+let b:did_spacevim_cs_ftplugin = 1
+
+let b:ale_linters = ['OmniSharp']
+
+compiler dotnet
+
+if spacevim#load('lightline')
+  "b:lightline didn't work, g:lightline does
+  "Maybe direct to a function based on filetype?
+  let g:lightline['component'] = {
+  \	'sharpenup': sharpenup#statusline#Build()
+  \}
+
+  augroup setupOmniSharpLightlineIntegration
+    autocmd!
+    autocmd User OmniSharpProjectUpdated,OmniSharpReady call lightline#update()
+  augroup END
+endif
+
+" [re]defines :Make command, with autocomplete to a csproj in the sln
+command! -bang -nargs=* -bar -complete=custom,s:DotNetFileComplete Make AsyncRun -program=make @ <args>
+
+" Find relevant .csproj files to populate autocomplete list
+" See `:help command-completion-custom`
+function! s:DotNetFileComplete(A,L,P)
+  let searchdir = expand('%:.:h')
+  let matches = ''
+  " If we're not relative to the cwd (e.g. in :help), don't try to search
+  if fnamemodify(searchdir,':p:h') !=? searchdir
+    let host = OmniSharp#GetHost(bufnr('%'))
+    let csprojs = deepcopy(host.job.projects)
+    let csprojs_relative = map(csprojs, {index, value -> fnamemodify(value['path'], ':.')})
+    if has_key(host, 'project')
+      " Make the first project this file is in first in the sln list
+      let project = fnamemodify(host['project']['MsBuildProject']['Path'], ':.')
+      let i = index(csprojs_relative, project)
+      call remove(csprojs_relative, i)
+      let matches = join(insert(csprojs_relative, project), "\n")
+    else
+      let matches = join(csprojs_relative, "\n")
+    endif
+  endif
+  return matches
+endfunction
+
+command! -buffer -bar OmniSharpBuildProject call s:OmniSharpBuildProject()
+command! -buffer -bar OmniSharpBuildSolution call s:OmniSharpBuildSolution()
+nnoremap <buffer> <Plug>(omnisharp_build_project) :OmniSharpBuildProject<CR>
+nnoremap <buffer> <Plug>(omnisharp_build_solution) :OmniSharpBuildSolution<CR>
+
+function! s:OmniSharpBuildProject() abort
+  let host = OmniSharp#GetHost(bufnr('%'))
+  let CsprojF = {->fnamemodify(host['project']['MsBuildProject']['Path'], ':.')}
+  if has_key(host, 'project')
+    call execute('Make '.CsprojF())
+  else
+    call OmniSharp#actions#project#Get(bufnr('%'), { -> execute('Make '.CsprojF()) })
+  endif
+endfunction
+
+function! s:OmniSharpBuildSolution() abort
+  let sln = OmniSharp#GetHost(bufnr('%')).sln_or_dir
+  call execute('Make '.sln)
+endfunction

--- a/layers/+lang/csharp/README.md
+++ b/layers/+lang/csharp/README.md
@@ -1,0 +1,52 @@
+# C# Layer
+
+## Table of Contents
+
+<!-- vim-markdown-toc GFM -->
+* [Description](#description)
+* [Install](#install)
+* [Key Bindings](#keybindings)
+
+<!-- vim-markdown-toc -->
+
+## Description
+
+This layer adds support for the C# language.
+
+## Install
+
+To use this configuration layer, add it to your `.spacevim`.
+
+## Key Bindings
+
+Here are most/all:
+
+```vim
+let g:OmniSharp_popup_mappings = {
+\ 'close': ['<Esc>', 'gq']
+\ 'lineDown': '<C-e>',
+\ 'lineUp': '<C-y>',
+\ 'halfPageDown': '<C-d>',
+\ 'halfPageUp': '<C-u>',
+\ 'pageDown': ['<C-f>', '<PageDown>'],
+\ 'pageUp': ['<C-b>', '<PageUp>']
+\ 'sigNext': '<C-j>',
+\ 'sigPrev': '<C-k>',
+\ 'sigParamNext': '<C-l>',
+\ 'sigParamPrev': '<C-h>'
+\}
+
+nmap <C-\> <Plug>(omnisharp_signature_help)
+imap <C-\> <Plug>(omnisharp_signature_help)
+nmap <silent> <buffer> [[ <Plug>(omnisharp_navigate_up)
+nmap <silent> <buffer> ]] <Plug>(omnisharp_navigate_down)
+"nmap <prefix>ca <Plug>(omnisharp_code_actions)
+"xmap <prefix>ca <Plug>(omnisharp_code_actions)
+"nmap <silent> <buffer> <prefix>. <Plug>(omnisharp_code_action_repeat)
+"xmap <silent> <buffer> <prefix>. <Plug>(omnisharp_code_action_repeat)
+```
+
+The remainder are integrated with *vim-which-key* in the `<leader>/+lsp` category.
+
+See [OmniSharp/omnisharp-vim](https://github.com/OmniSharp/omnisharp-vim) for some bindings documentation. See `:help omnisharp`.
+[nickspoons/vim-sharpenup](https://github.com/nickspoons/vim-sharpenup) includes some keybindings but they are not enabled and were instead integrated with *space-vim* and *vim-which-key*.

--- a/layers/+lang/csharp/config.vim
+++ b/layers/+lang/csharp/config.vim
@@ -1,0 +1,180 @@
+" OmniSharp/omnisharp-vim: {
+  let g:OmniSharp_popup_position = winwidth(0) >= 80 ? 'peek' : 'center'
+  if has('nvim')
+    let g:OmniSharp_popup_options = {
+    \ 'winhl': 'Normal:NormalFloat'
+    \}
+  else
+    let g:OmniSharp_popup_options = {
+    \ 'highlight': 'Normal',
+    \ 'padding': [0, 0, 0, 0],
+    \ 'border': [1]
+    \}
+  endif
+  let g:OmniSharp_popup_mappings = {
+  \ 'pageDown': ['<C-f>', '<PageDown>'],
+  \ 'pageUp': ['<C-b>', '<PageUp>']
+  \}
+
+  "if s:using_snippets
+  "  let g:OmniSharp_want_snippet = 1
+  "endif
+
+  let g:OmniSharp_highlight_groups = {
+  \ 'ExcludedCode': 'NonText'
+  \}
+  "\ 'Comment': 'NonText',
+  "\ 'XmlDocCommentName': 'Identifier',
+  "\ 'XmlDocCommentText': 'NonText'
+  "\}
+
+  if spacevim#load('clap')
+    let g:OmniSharp_selector_findusages = 'clap'
+  endif
+  let g:OmniSharp_autoselect_existing_sln = 1
+  let g:OmniSharp_highlighting = 3
+  let g:OmniSharp_diagnostic_exclude_paths = [ 'Temp[/\\]', 'obj[/\\]', '\.nuget[/\\]' ]
+  "let g:OmniSharp_fzf_options = { 'down': '10'  }']]]' ]
+
+  " The following autoformats the code on write per OmniSharp
+  " configuration when g:OmniSharp_code_format is set.
+  " Each codebase might have different configuration.
+  " Some codebases might be messy, where autoformat is a burden in making patches, thus this is false by default.
+  " https://github.com/OmniSharp/omnisharp-roslyn/wiki/Configuration-Options
+  let g:OmniSharp_code_format = v:false
+  augroup codeformatOmniSharp
+    autocmd!
+    autocmd BufWritePre *.cs :if g:OmniSharp_code_format | :OmniSharpCodeFormat | :endif
+  augroup END
+
+  " Cache the 'project' data from OmniSharp-Roslyn to each cs buffer
+  augroup cacheOmniSharpProject
+    autocmd!
+    autocmd FileType cs call s:CacheOmniSharpProjectInBuffer({->0})
+  augroup END
+
+  function! s:CacheOmniSharpProjectInBuffer(callback)
+    if &filetype ==# 'cs'
+      let bufnr = bufnr('%')
+      let host = OmniSharp#GetHost(bufnr)
+      if !has_key(host, 'project')
+        " 'project' not in cache, must query from OmniSharp-Roslyn, is async
+        call OmniSharp#actions#project#Get(bufnr, a:callback)
+      endif
+    endif
+  endfunction
+
+  if spacevim#load('programming')
+    if exists('g:vista_executive_for') && v:t_dict == type(g:vista_executive_for)
+      call extend(g:vista_executive_for, {'cs': 'ctags'})
+    else
+      let g:vista_executive_for = {'cs': 'ctags'}
+    endif
+  endif
+" }
+
+" nickspoons/vim-sharpenup: {
+  " We want everything from vim-sharpenup but the keybindings due to integration
+  let g:sharpenup_create_mappings = 0
+  let g:sharpenup_map_legacy_csproj_actions = 0
+
+  " TODO: integrate mappings better:
+  nmap <C-\> <Plug>(omnisharp_signature_help)
+  imap <C-\> <Plug>(omnisharp_signature_help)
+  nmap <silent> <buffer> [[ <Plug>(omnisharp_navigate_up)
+  nmap <silent> <buffer> ]] <Plug>(omnisharp_navigate_down)
+  "nmap <prefix>ca <Plug>(omnisharp_code_actions)
+  "xmap <prefix>ca <Plug>(omnisharp_code_actions)
+  "nmap <silent> <buffer> <prefix>. <Plug>(omnisharp_code_action_repeat)
+  "xmap <silent> <buffer> <prefix>. <Plug>(omnisharp_code_action_repeat)
+
+  " A `Dictionary-function` containing vim-which-key mappings
+  function! s:whichkey_omnisharp_integration()
+    if &filetype ==# 'cs'
+      let s:new_keymap = get(s:, 'new_keymap', {
+      \ 'name': '+omnisharp',
+      \ '.': ['<Plug>(omnisharp_code_action_repeat)', 'repeat'],
+      \ 'a': ['<Plug>(omnisharp_code_actions)'      , 'code-action'],
+      \ 'c': ['<Plug>(omnisharp_global_code_check)' , 'global-code-check'],
+      \ 'f': ['<Plug>(omnisharp_code_format)'       , 'formatting'],
+      \ 'h': ['<Plug>(omnisharp_signature_help)'    , 'hover'],
+      \ 'H': ['<Plug>(omnisharp_highlight)'         , 'highlight'],
+      \ 'r': ['<Plug>(omnisharp_find_usages)'       , 'references'],
+      \ 'R': ['<Plug>(omnisharp_rename)'            , 'rename'],
+      \ 's': ['<Plug>(omnisharp_documentation)'     , 'document-symbol'],
+      \ 'S': ['<Plug>(omnisharp_find_symbol)'       , 'workspace-symbol'],
+      \ 'g': {
+        \ 'name': '+goto',
+        \ 'd': ['<Plug>(omnisharp_go_to_definition)', 'definition'],
+        \ 't': ['<Plug>(omnisharp_find_type)'       , 'type-definition'],
+        \ 'i': ['<Plug>(omnisharp_find_implementations)', 'implementation'],
+        \ 's': ['<Plug>(omnisharp_find_symbol)'     , 'symbol'],
+        \ },
+      \ 'p': {
+        \ 'name': '+preview',
+        \ 'd': ['<Plug>(omnisharp_preview_definition)'     , 'definition'],
+        \ 'i': ['<Plug>(omnisharp_preview_implementations)', 'implementation'],
+        \ },
+      \ 'b': {
+        \ 'name': '+build',
+        \ 'p': ['<Plug>(omnisharp_build_project)'      , 'build-project'],
+        \ 's': ['<Plug>(omnisharp_build_solution)'     , 'build-solution'],
+        \ 'd': ['<Plug>(omnisharp_debug_project)'      , 'debug-project'],
+        \ 'v': ['<Plug>(omnisharp_create_debug_config)', 'create-vimspector-config'],
+        \ },
+      \ 't': {
+        \ 'name': '+test',
+        \ 't': ['<Plug>(omnisharp_run_test)'         , 'run-test'],
+        \ 'n': ['<Plug>(omnisharp_run_test_no_build)', 'run-test-no-build'],
+        \ 'T': ['<Plug>(omnisharp_run_tests_in_file)', 'run-tests-in-file'],
+        \ 'N': ['<Plug>(omnisharp_run_tests_in_file_no_build)', 'run-tests-in-file-no-build'],
+        \ 'd': ['<Plug>(omnisharp_debug_test)'         , 'debug-test'],
+        \ 'D': ['<Plug>(omnisharp_debug_test_no_build)', 'debug-test-no-build'],
+        \ },
+      \ 'x': {
+        \ 'name': '+csproj-modify',
+        \ 'a': ['<Plug>(omnisharp_add_to_csproj)'   , 'add-to-csproj'],
+        \ 'r': ['<Plug>(omnisharp_rename_in_csproj)', 'rename-in-csproj'],
+        \ },
+      \ 'X': {
+        \ 'name': '+server',
+        \ 's': [':OmniSharpStatus!'                    , 'status'],
+        \ 'S': ['<Plug>(omnisharp_start_server)'       , 'start'],
+        \ 't': ['<Plug>(omnisharp_stop_server)'        , 'stop'],
+        \ 'T': ['<Plug>(omnisharp_stop_all_servers)'   , 'stop-all'],
+        \ 'r': ['<Plug>(omnisharp_restart_server)'     , 'restart'],
+        \ 'R': ['<Plug>(omnisharp_restart_all_servers)', 'restart-all'],
+        \ },
+      \ })
+      return s:new_keymap
+    else
+      return s:keep_keymap
+    endif
+  endfunction
+
+  " Integrate OmniSharp hotkeys with vim-which-key
+  if spacevim#load('which-key')
+    let s:keep_keymap = get(s:, 'keep_keymap', deepcopy(g:spacevim#map#leader#desc['l']))
+    let g:spacevim#map#leader#desc['l'] = function('s:whichkey_omnisharp_integration')
+  endif
+" }
+
+" mattn/vim-lsp-settings: {
+  if exists('g:spacevim_lsp_engine') && g:spacevim_lsp_engine ==# 'vim_lsp'
+    let g:lsp_settings = get(g:, 'lsp_settings', {})
+    if !has_key(g:lsp_settings, 'omnisharp-lsp')
+      let g:lsp_settings['omnisharp-lsp'] = {}
+    endif
+    let g:lsp_settings['omnisharp-lsp'].disabled = 1
+  endif
+" }
+
+" itchyny/lightline.vim: {
+  let g:sharpenup_statusline_opts = { 'Text': '%s (%p/%P)' }
+  let g:sharpenup_statusline_opts.Highlight = 0
+" }
+
+" As alternative to OmniSharpCodeFormat, can use different formatter
+" vim-autoformat/vim-autoformat: {
+  "let g:formatdef_my_custom_cs = '"astyle --mode=cs --style=ansi -pcHs".&shiftwidth'
+" }

--- a/layers/+lang/csharp/packages.vim
+++ b/layers/+lang/csharp/packages.vim
@@ -1,0 +1,3 @@
+MP 'OmniSharp/omnisharp-vim', { 'on_ft' : 'cs' }
+MP 'nickspoons/vim-sharpenup', { 'on_ft' : 'cs' }
+MP 'nickspoons/vim-cs', { 'on_ft' : 'cs' }

--- a/layers/+programming/programming/config.vim
+++ b/layers/+programming/programming/config.vim
@@ -83,7 +83,8 @@ augroup END
 
 " vim-polyglot {
   " Reset errorformat to its default value for cooperating with asyncrun.vim
-  autocmd BufEnter * set errorformat&
+  " BUG: Prevents other plugins from including CompilerSets
+  "autocmd BufEnter * set errorformat&
 " }
 
 " vim-rooter {

--- a/layers/LAYERS.md
+++ b/layers/LAYERS.md
@@ -1,7 +1,7 @@
 Layer Manifest
 ==============
 
-Last updated: 2022-09-29 12:26:10
+Last updated: 2022-09-29 12:39:45
 
 Default layers: `fzf`, `better-defaults` and `which-key`.
 
@@ -19,6 +19,7 @@ Topic                | Layer | Plugins
 +fun                 | [goyo](https://github.com/liuchengxu/space-vim/tree/master/layers/+fun/goyo) | <ul><li>[junegunn/goyo.vim](https://github.com/junegunn/goyo.vim)</li><li>[junegunn/limelight.vim](https://github.com/junegunn/limelight.vim)</li></ul>
 +lang                | [c-c++](https://github.com/liuchengxu/space-vim/tree/master/layers/+lang/c-c++) | <ul><li>[octol/vim-cpp-enhanced-highlight](https://github.com/octol/vim-cpp-enhanced-highlight)</li><li>[rhysd/vim-clang-format](https://github.com/rhysd/vim-clang-format)</li></ul>
 +lang                | [clojure](https://github.com/liuchengxu/space-vim/tree/master/layers/+lang/clojure) | <ul><li>[guns/vim-clojure-highlight](https://github.com/guns/vim-clojure-highlight)</li><li>[guns/vim-clojure-static](https://github.com/guns/vim-clojure-static)</li><li>[guns/vim-slamhound](https://github.com/guns/vim-slamhound)</li><li>[kovisoft/paredit](https://github.com/kovisoft/paredit)</li><li>[tpope/vim-fireplace](https://github.com/tpope/vim-fireplace)</li><li>[venantius/vim-cljfmt](https://github.com/venantius/vim-cljfmt)</li></ul>
++lang                | [csharp](https://github.com/liuchengxu/space-vim/tree/master/layers/+lang/csharp) | <ul><li>[OmniSharp/omnisharp-vim](https://github.com/OmniSharp/omnisharp-vim)</li><li>[nickspoons/vim-cs](https://github.com/nickspoons/vim-cs)</li><li>[nickspoons/vim-sharpenup](https://github.com/nickspoons/vim-sharpenup)</li></ul>
 +lang                | [elixir](https://github.com/liuchengxu/space-vim/tree/master/layers/+lang/elixir) | <ul><li>[elixir-lang/vim-elixir](https://github.com/elixir-lang/vim-elixir)</li><li>[slashmili/alchemist.vim](https://github.com/slashmili/alchemist.vim)</li></ul>
 +lang                | [elm](https://github.com/liuchengxu/space-vim/tree/master/layers/+lang/elm) | <ul><li>[ElmCast/elm-vim](https://github.com/ElmCast/elm-vim)</li></ul>
 +lang                | [erlang](https://github.com/liuchengxu/space-vim/tree/master/layers/+lang/erlang) | <ul><li>[vim-erlang/erlang-motions.vim](https://github.com/vim-erlang/erlang-motions.vim)</li><li>[vim-erlang/vim-erlang-compiler](https://github.com/vim-erlang/vim-erlang-compiler)</li><li>[vim-erlang/vim-erlang-omnicomplete](https://github.com/vim-erlang/vim-erlang-omnicomplete)</li><li>[vim-erlang/vim-erlang-skeletons](https://github.com/vim-erlang/vim-erlang-skeletons)</li><li>[vim-erlang/vim-erlang-tags](https://github.com/vim-erlang/vim-erlang-tags)</li></ul>


### PR DESCRIPTION
Adds [OmniSharp-vim](https://github.com/OmniSharp/omnisharp-vim) for C# language. Predates the advent of LSP, and at present has more features than using an LSP client and OmniSharp-Rosyln in LSP mode.

Includes ['nickspoons/vim-sharpenup'](https://github.com/nickspoons/vim-sharpenup) but doesn't use those mappings.

Uses vim-clap for selection it is loaded, otherwise quickfix list.

I don't use snippets so hadn't configured anything there.

Build options:
1. Defines `:Make` command which autocompletes to a *.csproj in the solution.
2. Defines `OmniSharpBuildProject` and `OmniSharpBuildSolution`.
3. vim-which-key e.g. `<leader>lbp` to build current project.
4. Eventually plumbing will include a better/modern vim CompilerSet 'nickspoons/vim-cs', the current C# ones distributed in vim are archaic and not relevant.

Disables space-vim programming layer from resetting errorformat. Eventually will include ['nickspoons/vim-cs'](https://github.com/nickspoons/vim-cs). That CompilerSet will probably modify errorformat.