### PR TITLE
Fix editorconfig prompt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 insert_final_newline = true
-charset = utf_8
+charset = utf-8
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
```
editorconfig: invalid value for option charset: utf_8. charset must be one of "utf-8", "utf-8-bom", "latin1", "utf-16be", or "utf-16le"
```