### PR TITLE
layers: nerdtree: remove autocmd for bufEnter and bufNew

### DIFF
--- a/layers/+tools/file-manager/packages.vim
+++ b/layers/+tools/file-manager/packages.vim
@@ -9,11 +9,6 @@ else
   augroup loadNerdtree
     autocmd!
     autocmd VimEnter * silent! autocmd! FileExplorer
-    autocmd BufEnter,BufNew *
-                \  if isdirectory(expand('<amatch>'))
-                \|   call plug#load('nerdtree')
-                \|   call nerdtree#checkForBrowse(expand("<amatch>"))
-                \| endif
   augroup END
 
   if get(g:, 'spacevim_nerd_fonts', 0)


### PR DESCRIPTION
This causes problems along with the fzf layer and some of the buffer information is lost due to the nerdtree overriding that buffer with it's own, not sure where the origination is from but this seems to fix the problem